### PR TITLE
feat: add laravel testing and require php 8.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,8 @@ It will grow as the project evolves.
 
 ## Testing
 - Run front-end tests with `npm test` inside `ui/`.
-- The Laravel package currently has no automated tests; manually verify changes.
+- Run Laravel package tests with `composer test` inside `laravel/`.
 
 ## Pull requests
 - Keep commits focused and reference relevant documentation when introducing new patterns.
 - Update this file and other docs as conventions evolve.
-

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -1,10 +1,25 @@
 {
     "name": "tmarois/atlas-laravel",
     "description": "Reusable Laravel base framework",
+    "require": {
+        "php": "^8.3"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^11.0"
+    },
     "autoload": {
         "psr-4": {
             "Atlas\\Laravel\\": "src/",
             "Atlas\\Laravel\\Support\\Phone\\": "src/Support/Phone/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Atlas\\Laravel\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Atlas Laravel Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/laravel/tests/Support/PhoneNumberTest.php
+++ b/laravel/tests/Support/PhoneNumberTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Atlas\Laravel\Tests\Support;
+
+use Atlas\Laravel\Support\Phone\PhoneNumber;
+use PHPUnit\Framework\TestCase;
+
+class PhoneNumberTest extends TestCase
+{
+    public function test_format_returns_formatted_number(): void
+    {
+        $this->assertSame('(123) 456-7890', PhoneNumber::format('1234567890'));
+    }
+
+    public function test_format_returns_null_for_empty_input(): void
+    {
+        $this->assertNull(PhoneNumber::format(null));
+    }
+
+    public function test_normalize_strips_country_code_and_symbols(): void
+    {
+        $this->assertSame('1234567890', PhoneNumber::normalize('+1 (123) 456-7890'));
+    }
+
+    public function test_normalize_returns_null_for_invalid_number(): void
+    {
+        $this->assertNull(PhoneNumber::normalize('123'));
+    }
+}


### PR DESCRIPTION
## Summary
- require PHP 8.3 and add PHPUnit/Testbench for the Laravel package
- add PhoneNumber unit tests and PHPunit config
- document how to run tests

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8822a87fc8325ad8271bad5e64bf8