### PR TITLE
refactor: move phone helper to global support namespace

### DIFF
--- a/docs/laravel/support.md
+++ b/docs/laravel/support.md
@@ -1,0 +1,30 @@
+# Support Helpers
+
+Atlas Laravel ships with small utility classes under the `Atlas\Laravel\Support` namespace.
+
+## PhoneNumber
+
+Format and normalize US phone numbers.
+
+```php
+use Atlas\Laravel\Support\PhoneNumber;
+
+PhoneNumber::format('1234567890'); // (123) 456-7890
+PhoneNumber::normalize('+1 (123) 456-7890'); // 1234567890
+```
+
+## Caster
+
+Cast simple data arrays using type definitions.
+
+```php
+use Atlas\Laravel\Support\Caster;
+
+$data = ['count' => '1', 'active' => '1'];
+$casts = ['count' => 'int', 'active' => 'bool'];
+
+$cast = Caster::cast($data, $casts);
+// ['count' => 1, 'active' => true]
+```
+
+These helpers are designed to be lightweight and framework agnostic, making them easy to reuse across projects.

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -10,8 +10,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Atlas\\Laravel\\": "src/",
-            "Atlas\\Laravel\\Support\\Phone\\": "src/Support/Phone/"
+            "Atlas\\Laravel\\": "src/"
         }
     },
     "autoload-dev": {

--- a/laravel/src/Support/PhoneNumber.php
+++ b/laravel/src/Support/PhoneNumber.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Atlas\Laravel\Support\Phone;
+namespace Atlas\Laravel\Support;
 
 class PhoneNumber
 {

--- a/laravel/tests/Support/PhoneNumberTest.php
+++ b/laravel/tests/Support/PhoneNumberTest.php
@@ -2,7 +2,7 @@
 
 namespace Atlas\Laravel\Tests\Support;
 
-use Atlas\Laravel\Support\Phone\PhoneNumber;
+use Atlas\Laravel\Support\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
 class PhoneNumberTest extends TestCase


### PR DESCRIPTION
## Summary
- move `PhoneNumber` helper into the main `Support` namespace
- adjust autoloading and tests for new namespace
- document Support helpers and usage examples

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a8868a37508325be6392a5ac3ff044