### PR TITLE
feat(ui): add US phone number formatter

### DIFF
--- a/docs/ui/utils.md
+++ b/docs/ui/utils.md
@@ -10,6 +10,7 @@
   - [formatPercentage](#formatpercentage)
   - [formatSlug](#formatslug)
   - [formatValidURL](#formatvalidurl)
+  - [formatUSPhoneNumber](#formatusphonenumber)
 - [Validation Utilities](#validation-utilities)
   - [isEmpty](#isempty)
   - [isNumeric](#isnumeric)
@@ -159,6 +160,27 @@ formatValidURL('google.com');                // 'http://google.com'
 formatValidURL('google.com', true);         // 'https://google.com'
 formatValidURL('http://example.com');       // 'http://example.com'
 formatValidURL('http://example.com', true); // 'https://example.com'
+```
+
+### formatUSPhoneNumber
+
+Formats a US-based phone number from 10 digits into `(999) 999-9999` format. If the
+input includes a leading `1` (e.g. `19995551234`), the extra digit is ignored. An
+optional flag can prefix the result with `+1`.
+
+**Parameters:**
+- `phoneNumber` (string | number): The phone number to format (10 digits or 11 digits starting with `1`)
+- `withCountryCode` (boolean, optional): Prefix the formatted number with `+1` (default: `false`)
+
+**Returns:** The formatted phone number string (e.g. `(123) 456-7890` or `+1 (123) 456-7890`)
+
+**Example:**
+```typescript
+import { formatUSPhoneNumber } from '@tmarois/atlas';
+
+formatUSPhoneNumber('1234567890'); // '(123) 456-7890'
+formatUSPhoneNumber(9876543210, true); // '+1 (987) 654-3210'
+formatUSPhoneNumber('19998887777'); // '(999) 888-7777'
 ```
 
 ## Validation Utilities

--- a/ui/src/utils/format/formatUSPhoneNumber.ts
+++ b/ui/src/utils/format/formatUSPhoneNumber.ts
@@ -1,0 +1,25 @@
+/**
+ * Format a US-based phone number from 9999999999 to (999) 999-9999
+ *
+ * Optionally include the country code, returning +1 (999) 999-9999.
+ * If the input includes a leading "1" (e.g. 19995551234), the extra
+ * digit is stripped before formatting.
+ *
+ * @param phoneNumber - The phone number to format
+ * @param withCountryCode - When true, prefix the formatted number with +1
+ * @returns The formatted phone number string
+ */
+export const formatUSPhoneNumber = (
+    phoneNumber: string | number,
+    withCountryCode = false,
+): string => {
+    if (!phoneNumber) return '';
+
+    const digits = phoneNumber.toString().replace(/\D/g, '');
+    const normalized = digits.length === 11 && digits.startsWith('1') ? digits.slice(1) : digits;
+
+    if (normalized.length !== 10) return '';
+
+    const formatted = `(${normalized.slice(0, 3)}) ${normalized.slice(3, 6)}-${normalized.slice(6)}`;
+    return withCountryCode ? `+1 ${formatted}` : formatted;
+};

--- a/ui/src/utils/format/index.ts
+++ b/ui/src/utils/format/index.ts
@@ -6,3 +6,4 @@ export * from './formatNumber';
 export * from './formatPercentage';
 export * from './formatSlug';
 export * from './formatValidURL';
+export * from './formatUSPhoneNumber';

--- a/ui/tests/utils/format/formatUSPhoneNumber.test.ts
+++ b/ui/tests/utils/format/formatUSPhoneNumber.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { formatUSPhoneNumber } from '../../../src/utils/format/formatUSPhoneNumber';
+
+describe('formatUSPhoneNumber', () => {
+    // Happy path tests
+    it('should format numeric phone number', () => {
+        expect(formatUSPhoneNumber(1234567890)).toBe('(123) 456-7890');
+    });
+
+    it('should format string phone number', () => {
+        expect(formatUSPhoneNumber('9876543210')).toBe('(987) 654-3210');
+    });
+
+    it('should include country code when requested', () => {
+        expect(formatUSPhoneNumber('1234567890', true)).toBe('+1 (123) 456-7890');
+    });
+
+    it('should handle leading country code in input', () => {
+        expect(formatUSPhoneNumber('19998887777')).toBe('(999) 888-7777');
+    });
+
+    it('should handle leading country code in input and output', () => {
+        expect(formatUSPhoneNumber('19998887777', true)).toBe('+1 (999) 888-7777');
+    });
+
+    // Bad path tests
+    it('should return empty string for invalid length', () => {
+        expect(formatUSPhoneNumber('123')).toBe('');
+    });
+
+    it('should return empty string for empty input', () => {
+        expect(formatUSPhoneNumber('')).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary
- add US-based phone number formatter util
- document phone number format utility
- test number formatter utility

## Testing
- `cd ui && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a88b74c9f483258a82dfaf09b6f0cc