### PR TITLE
feat(ui): add button component

### DIFF
--- a/ui/src/components/AButton.vue
+++ b/ui/src/components/AButton.vue
@@ -1,0 +1,60 @@
+<template>
+    <Button
+        unstyled
+        :pt="theme"
+        :ptOptions="{
+            mergeProps: ptViewMerge
+        }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Button>
+</template>
+
+<script setup lang="ts">
+import Button, { type ButtonPassThroughOptions, type ButtonProps } from 'primevue/button';
+import { ref } from 'vue';
+import { ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ ButtonProps {}
+defineProps<Props>();
+
+const theme = ref<ButtonPassThroughOptions>({
+    root: `inline-flex cursor-pointer select-none items-center justify-center overflow-hidden relative
+        px-4 py-3 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
+        bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
+        border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10
+        p-icon-only:w-10 p-icon-only:px-0 p-icon-only:gap-0
+        p-icon-only:p-rounded:rounded-full p-icon-only:p-rounded:h-10
+        p-small:text-sm p-small:px-4px p-small:py-[0.375rem]
+        p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
+        p-raised:shadow-sm p-rounded:rounded-[2rem]
+        p-outlined:bg-transparent enabled:hover:p-outlined:bg-primary-50 enabled:active:p-outlined:bg-primary-100
+        p-outlined:border-primary-200 enabled:hover:p-outlined:border-primary-200 enabled:active:p-outlined:border-primary-200
+        p-outlined:text-primary enabled:hover:p-outlined:text-primary enabled:active:p-outlined:text-primary
+        dark:p-outlined:bg-transparent dark:enabled:hover:p-outlined:bg-primary/5 dark:enabled:active:p-outlined:bg-primary/15
+        dark:p-outlined:border-primary-300 dark:enabled:hover:p-outlined:border-primary-200 dark:enabled:active:p-outlined:border-primary-500
+        dark:p-outlined:text-primary-300 dark:enabled:hover:p-outlined:text-primary-200 dark:enabled:active:p-outlined:text-primary-200
+        p-text:bg-transparent enabled:hover:p-text:bg-gray-100 enabled:active:p-text:bg-primary-100
+        p-text:border-transparent enabled:hover:p-text:border-transparent enabled:active:p-text:border-transparent
+        p-text:text-gray-700 enabled:hover:p-text:text-gray-700 enabled:active:p-text:text-gray-700
+        dark:p-text:bg-transparent dark:enabled:hover:p-text:bg-primary/5 dark:enabled:active:p-text:bg-primary/15
+        dark:p-text:border-transparent dark:enabled:hover:p-text:border-transparent dark:enabled:active:p-text:border-transparent
+        dark:p-text:text-white dark:enabled:hover:p-text:text-primary dark:enabled:active:p-text:text-primary
+        p-large:px-4 p-large:py-3
+    `,
+    loadingIcon: `animate-spin`,
+    icon: `p-right:order-1 p-bottom:order-2`,
+    label: `
+            p-icon-only:invisible p-icon-only:w-0
+            p-small:text-sm
+            p-large:text-base p-large:font-bold
+        `,
+    pcBadge: {
+        root: `min-w-4 h-4 leading-4 bg-primary-contrast rounded-full text-primary text-xs font-bold`
+    }
+});
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -1,0 +1,1 @@
+export { default as AButton } from './AButton.vue';

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,2 +1,3 @@
+export * from './components';
 export * from './composables';
 export * from './utils';

--- a/ui/src/shims-vue.d.ts
+++ b/ui/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue';
+    const component: DefineComponent<{}, {}, any>;
+    export default component;
+}


### PR DESCRIPTION
## Summary
- add PrimeVue-based `AButton` component with theme pass-through
- expose components through new index and top-level exports
- include Vue type shim for `.vue` modules

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit && echo tsc_ok`


------
https://chatgpt.com/codex/tasks/task_b_68a8af6ff2f08325ae6fab9e902d7011