### PR TITLE
feat(ui): add checkbox and input components

### DIFF
--- a/ui/src/components/ACheckbox.vue
+++ b/ui/src/components/ACheckbox.vue
@@ -1,0 +1,53 @@
+<template>
+    <Checkbox
+        unstyled
+        :pt="theme"
+        :ptOptions="{
+            mergeProps: ptViewMerge
+        }"
+    >
+        <template #icon="{ checked, indeterminate, dataP }">
+            <CheckIcon v-if="checked" :class="theme.icon" :data-p="dataP" />
+            <MinusIcon v-else-if="indeterminate" :class="theme.icon" :data-p="dataP" />
+        </template>
+    </Checkbox>
+</template>
+
+<script setup lang="ts">
+import CheckIcon from '@primevue/icons/check';
+import MinusIcon from '@primevue/icons/minus';
+import Checkbox, { type CheckboxPassThroughOptions, type CheckboxProps } from 'primevue/checkbox';
+import { ref } from 'vue';
+import { ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ CheckboxProps {}
+defineProps<Props>();
+
+const theme = ref<CheckboxPassThroughOptions>({
+    root: `relative inline-flex select-none w-5 h-5 align-bottom
+        p-small:w-4 p-small:h-4
+        p-large:w-6 p-large:h-6`,
+    input: `peer cursor-pointer disabled:cursor-default appearance-none
+        absolute start-0 top-0 w-full h-full m-0 p-0 opacity-0 z-10
+        border border-transparent rounded-xs`,
+    box: `flex justify-center items-center rounded-sm w-5 h-5
+        border border-surface-300 dark:border-surface-700
+        bg-surface-0 dark:bg-surface-950
+        text-surface-700 dark:text-surface-0
+        peer-enabled:peer-hover:border-surface-500 dark:peer-enabled:peer-hover:border-surface-600
+        p-checked:border-primary-400 p-checked:bg-primary-500 p-checked:text-primary-contrast
+        peer-enabled:peer-hover:p-checked:bg-primary-500/70 peer-enabled:peer-hover:p-checked:border-primary-emphasis
+        peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary peer-focus-visible:outline
+        p-invalid:border-red-400 dark:p-invalid:border-red-500
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        p-disabled:bg-surface-200 dark:p-disabled:bg-surface-400 p-disabled:border-surface-300 dark:p-disabled:border-surface-500 p-disabled:text-surface-700 dark:p-disabled:text-surface-400
+        shadow-[0_1px_2px_0_rgba(18,18,23,0.05)] transition-colors duration-200
+        p-small:w-4 p-small:h-4
+        p-large:w-6 p-large:h-6`,
+    icon: `text-sm w-[0.875rem] h-[0.875rem] transition-none
+        p-small:w-3 p-small:h-3
+        p-large:w-4 p-large:h-4
+        text-white p-disabled:text-surface-400 dark:p-disabled:text-surface-600`
+});
+</script>
+

--- a/ui/src/components/AInputMask.vue
+++ b/ui/src/components/AInputMask.vue
@@ -1,0 +1,38 @@
+<template>
+    <InputMask
+        unstyled
+        :pt="theme"
+        :ptOptions="{
+            mergeProps: ptViewMerge
+        }"
+    />
+</template>
+
+<script setup lang="ts">
+import InputMask, { type InputMaskPassThroughOptions, type InputMaskProps } from 'primevue/inputmask';
+import { ref } from 'vue';
+import { ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ InputMaskProps {}
+defineProps<Props>();
+
+const theme = ref<InputMaskPassThroughOptions>({
+    root: `appearance-none rounded outline-hidden
+        bg-surface-0 dark:bg-surface-950
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        text-surface-700 dark:text-surface-0
+        placeholder:text-surface-500 dark:placeholder:text-surface-400
+        border border-surface-300 dark:border-surface-700
+        enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+        enabled:focus:border-primary
+        disabled:bg-surface-200 disabled:text-surface-500
+        dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        p-invalid:placeholder:text-red-600 dark:p-invalid:placeholder:text-red-400
+        px-3 py-2 p-fluid:w-full
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+        transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
+});
+</script>
+

--- a/ui/src/components/AInputNumber.vue
+++ b/ui/src/components/AInputNumber.vue
@@ -1,0 +1,86 @@
+<template>
+    <InputNumber
+        unstyled
+        :pt="theme"
+        :ptOptions="{
+            mergeProps: ptViewMerge
+        }"
+    >
+        <template #incrementicon>
+            <AngleUpIcon />
+        </template>
+        <template #decrementicon>
+            <AngleDownIcon />
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </InputNumber>
+</template>
+
+<script setup lang="ts">
+import AngleDownIcon from '@primevue/icons/angledown';
+import AngleUpIcon from '@primevue/icons/angleup';
+import InputNumber, { type InputNumberPassThroughOptions, type InputNumberProps } from 'primevue/inputnumber';
+import { ref } from 'vue';
+import { ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ InputNumberProps {}
+defineProps<Props>();
+
+const theme = ref<InputNumberPassThroughOptions>({
+    root: `inline-flex relative
+        p-vertical:flex-col p-fluid:w-full`,
+    pcInputText: {
+        root: `appearance-none rounded-md outline-hidden flex-auto
+        bg-surface-0 dark:bg-surface-950
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        text-surface-700 dark:text-surface-0
+        placeholder:text-surface-500 dark:placeholder:text-surface-400
+        border border-surface-300 dark:border-surface-700
+        enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+        enabled:focus:border-primary
+        disabled:bg-surface-200 disabled:text-surface-500
+        dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+        p-invalid:border-red-400 dark:p-invalid:border-red-500
+        p-invalid:placeholder:text-red-600 dark:p-invalid:placeholder:text-red-400
+        px-3 py-2.5 p-fluid:w-full
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+        transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]
+        p-horizontal:order-2 p-horizontal:rounded-none
+        p-vertical:order-2 p-vertical:rounded-none p-vertical:text-center
+        p-fluid:w-[1%] p-fluid:p-vertical:w-full
+        disabled:opacity-70
+        `
+    },
+    buttonGroup: `p-stacked:flex p-stacked:flex-col p-stacked:absolute p-stacked:top-px p-stacked:end-px p-stacked:h-[calc(100%-2px)] p-stacked:z-10`,
+    incrementButton: `flex items-center justify-center grow-0 shrink-0 basis-auto cursor-pointer w-10
+        bg-transparent enabled:hover:bg-surface-100 enabled:active:bg-surface-200
+        border border-surface-300 enabled:hover:border-surface-300 enabled:active:border-surface-300
+        text-surface-400 enabled:hover:text-surface-500 enabled:active:text-surface-600
+        dark:bg-transparent dark:enabled:hover:bg-surface-800 dark:enabled:active:bg-surface-700
+        dark:border-surface-700 dark:enabled:hover:border-surface-700 dark:enabled:active:border-surface-700
+        dark:text-surface-400 dark:enabled:hover:text-surface-300 dark:enabled:active:text-surface-200
+        transition-colors duration-200 disabled:pointer-events-none
+        p-stacked:relative p-stacked:flex-auto p-stacked:border-none
+        p-stacked:p-0 p-stacked:rounded-tr-[5px]
+        p-horizontal:order-3 p-horizontal:rounded-e-md p-horizontal:border-s-0
+        p-vertical:py-2 p-vertical:order-1 p-vertical:rounded-ss-md p-vertical:rounded-se-md p-vertical:w-full p-vertical:border-b-0`,
+    incrementIcon: ``,
+    decrementButton: `flex items-center justify-center grow-0 shrink-0 basis-auto cursor-pointer w-10
+        bg-transparent enabled:hover:bg-surface-100 enabled:active:bg-surface-200
+        border border-surface-300 enabled:hover:border-surface-300 enabled:active:border-surface-300
+        text-surface-400 enabled:hover:text-surface-500 enabled:active:text-surface-600
+        dark:bg-transparent dark:enabled:hover:bg-surface-800 dark:enabled:active:bg-surface-700
+        dark:border-surface-700 dark:enabled:hover:border-surface-700 dark:enabled:active:border-surface-700
+        dark:text-surface-400 dark:enabled:hover:text-surface-300 dark:enabled:active:text-surface-200
+        transition-colors duration-200 disabled:pointer-events-none
+        p-stacked:relative p-stacked:flex-auto p-stacked:border-none
+        p-stacked:p-0 p-stacked:rounded-br-[5px]
+        p-horizontal:order-1 p-horizontal:rounded-s-md p-horizontal:border-e-0
+        p-vertical:py-2 p-vertical:order-3 p-vertical:rounded-ee-md p-vertical:rounded-es-md p-vertical:w-full p-vertical:border-t-0`,
+    decrementIcon: ``
+});
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -1,5 +1,8 @@
 export { default as AButton } from './AButton.vue';
 export { default as ACard } from './ACard.vue';
+export { default as ACheckbox } from './ACheckbox.vue';
+export { default as AInputMask } from './AInputMask.vue';
+export { default as AInputNumber } from './AInputNumber.vue';
 export { default as AInputText } from './AInputText.vue';
 export { default as ASelect } from './ASelect.vue';
 export { default as ATextarea } from './ATextarea.vue';


### PR DESCRIPTION
## Summary
- add checkbox component with themed pass-through styles and custom icons
- add input number component with increment/decrement icons and theming
- add input mask component with consistent styling
- export new components in UI index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8be729d408325b1babd87f665f466