### PR TITLE
feat(ui): add Alert component

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -16,6 +16,8 @@ Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
   - [Checkbox](#checkbox)
 - [Layout](#layout)
   - [Card](#card)
+- [Feedback](#feedback)
+  - [Alert](#alert)
 
 ### Actions
 
@@ -126,3 +128,19 @@ import { Card } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Card API](https://primevue.org/card/#api).
+
+### Feedback
+
+#### Alert
+```ts
+import { Alert } from '@atlas/ui';
+```
+
+```vue
+<Alert>Default message</Alert>
+```
+
+##### Props
+
+- `warning` – use warning styling.
+- `hideIcon` – hide the default icon.

--- a/ui/src/components/Alert.vue
+++ b/ui/src/components/Alert.vue
@@ -1,0 +1,72 @@
+<template>
+    <div v-bind="bindProps" :class="mergedPt.root.class">
+        <div v-if="!hideIcon" :class="mergedPt.iconContainer.class">
+            <slot name="icon">
+                <IconExclamationCircleFilled
+                    v-if="warning"
+                    :class="mergedPt.icon.class"
+                />
+                <IconInfoCircleFilled
+                    v-else
+                    :class="mergedPt.icon.class"
+                />
+            </slot>
+        </div>
+        <div :class="mergedPt.content.class">
+            <slot />
+        </div>
+        <div v-if="$slots.actions" :class="mergedPt.actions.class">
+            <slot name="actions" />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { IconInfoCircleFilled, IconExclamationCircleFilled } from '@tabler/icons-vue';
+import { useAttrs, computed } from 'vue';
+import { mergePT } from '../utils';
+
+interface AlertPassThroughOptions {
+    root?: any;
+    iconContainer?: any;
+    icon?: any;
+    content?: any;
+    actions?: any;
+}
+
+interface Props {
+    warning?: boolean;
+    hideIcon?: boolean;
+    pt?: AlertPassThroughOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    warning: false,
+    hideIcon: false,
+});
+const attrs = useAttrs();
+
+const theme = computed<AlertPassThroughOptions>(() => ({
+    root: `w-full p-4 flex border items-center space-x-4 rounded-md ${
+        props.warning
+            ? 'bg-yellow-100 border-yellow-300 dark:bg-yellow-700 dark:border-yellow-600 dark:text-surface-100'
+            : 'bg-surface-50 border-surface-300 dark:bg-surface-700 dark:border-surface-600 dark:text-surface-100'
+    }`,
+    iconContainer: '',
+    icon: `${
+        props.warning
+            ? 'size-8 text-yellow-600 dark:text-yellow-400'
+            : 'size-8 text-surface-600 dark:text-surface-400'
+    }`,
+    content: 'flex-1 w-full text-sm',
+    actions: 'flex items-center space-x-2',
+}));
+
+const mergedPt = computed(() => mergePT(theme.value, props.pt));
+
+const passThroughProps = computed(() => {
+    const { pt, warning, hideIcon, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -4,5 +4,6 @@ export { default as Checkbox } from './Checkbox.vue';
 export { default as InputMask } from './InputMask.vue';
 export { default as InputNumber } from './InputNumber.vue';
 export { default as InputText } from './InputText.vue';
+export { default as Alert } from './Alert.vue';
 export { default as Select } from './Select.vue';
 export { default as Textarea } from './Textarea.vue';

--- a/ui/tests/components/ptMerge.test.ts
+++ b/ui/tests/components/ptMerge.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
-import { Button, Card, Checkbox, InputMask, InputNumber, InputText, Select, Textarea } from '../../src/components';
+import { Alert, Button, Card, Checkbox, InputMask, InputNumber, InputText, Select, Textarea } from '../../src/components';
 
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -58,5 +58,11 @@ describe('pass-through prop merging', () => {
     it('Textarea merges pt classes', () => {
         const wrapper = mountWithPrime(Textarea, { pt: { root: { class: 'bg-red-500' } } });
         expect(wrapper.find('textarea').classes()).toContain('bg-red-500');
+    });
+
+    it('Alert merges pt classes', () => {
+        const wrapper = mountWithPrime(Alert, { pt: { root: { class: 'bg-red-500' } } });
+        expect(wrapper.element.className).toContain('bg-red-500');
+        expect(wrapper.element.className).not.toContain('bg-surface-50');
     });
 });


### PR DESCRIPTION
## Summary
- add customizable Alert component with pass-through class support
- document Alert usage in UI guide
- cover Alert in pass-through merging tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8cc8fb4f08325b3923ce92e6b3de8