### PR TITLE
refactor: remove duplicate padding classes

### DIFF
--- a/ui/src/components/AccordionContent.vue
+++ b/ui/src/components/AccordionContent.vue
@@ -20,7 +20,7 @@ const attrs = useAttrs();
 
 const theme = ref<AccordionContentPassThroughOptions>({
     root: `flex flex-col`,
-    content: `text-surface-700 dark:text-surface-0 pt-0 px-[1.125rem] px-6 pb-[1.125rem] text-base`,
+    content: `text-surface-700 dark:text-surface-0 pt-0 px-6 pb-[1.125rem] text-base`,
     transition: {
         enterFromClass: 'max-h-0',
         enterActiveClass: 'overflow-hidden transition-[max-height] duration-1000 ease-[cubic-bezier(0.42,0,0.58,1)]',

--- a/ui/src/components/AccordionHeader.vue
+++ b/ui/src/components/AccordionHeader.vue
@@ -25,7 +25,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<AccordionHeaderPassThroughOptions>({
-    root: `cursor-pointer disabled:pointer-events-none disabled:opacity-60 flex items-center justify-between p-[1.125rem] px-6 py-4 font-semibold
+    root: `cursor-pointer disabled:pointer-events-none disabled:opacity-60 flex items-center justify-between px-6 py-4 font-semibold
         text-surface-500 dark:text-surface-400
         hover:text-surface-700 dark:hover:text-surface-0
         hover:bg-surface-100 dark:hover:bg-surface-700


### PR DESCRIPTION
## Summary
- clean up AccordionContent padding declaration
- simplify AccordionHeader padding classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8e828c5a88325b3f9553564b855c5