### PR TITLE
feat(ui): add progress bar, menu button, and date picker

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -30,6 +30,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [InputMask](#inputmask)
   - [InputGroup](#inputgroup)
   - [InputOtp](#inputotp)
+  - [DatePicker](#datepicker)
   - [Select](#select)
   - [AutoComplete](#autocomplete)
   - [MultiSelect](#multiselect)
@@ -52,12 +53,14 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Chip](#chip)
   - [Badge](#badge)
 - [Navigation](#navigation)
+  - [ButtonMenu](#buttonmenu)
   - [Menu](#menu)
   - [Paginator](#paginator)
   - [Pagination](#pagination)
 - [Feedback](#feedback)
   - [Alert](#alert)
   - [Toast](#toast)
+  - [ProgressBar](#progressbar)
 
 ### Actions
 
@@ -159,6 +162,19 @@ import { InputOtp } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue InputOtp API](https://primevue.org/inputotp/#api).
+
+#### DatePicker
+```ts
+import { DatePicker } from '@atlas/ui';
+```
+
+```vue
+<DatePicker v-model="date" />
+```
+
+##### API
+
+See the [PrimeVue DatePicker API](https://primevue.org/datepicker/#api).
 
 #### Select
 ```ts
@@ -464,6 +480,30 @@ Refer to the [PrimeVue Badge API](https://primevue.org/badge/#api).
 
 ### Navigation
 
+#### ButtonMenu
+```ts
+import { ButtonMenu } from '@atlas/ui';
+```
+
+```vue
+<ButtonMenu :items="items" @action="onAction" />
+```
+
+##### Props
+
+- `items` – array of menu item objects.
+- `icon` – icon class for the default trigger. Defaults to `'pi pi-ellipsis-v'`.
+- `ptData` – additional data passed with the `action` event.
+- `onHover` – show menu on hover instead of click.
+
+##### Slots
+
+- `trigger` – custom trigger element. Receives `{ toggleMenu, triggerRef }`.
+
+##### Events
+
+- `action` – emitted when an item is selected. Arguments: `(action, ptData)`.
+
 #### Menu
 ```ts
 import { Menu } from '@atlas/ui';
@@ -532,3 +572,16 @@ import { Toast } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Toast API](https://primevue.org/toast/#api).
+
+#### ProgressBar
+```ts
+import { ProgressBar } from '@atlas/ui';
+```
+
+```vue
+<ProgressBar :value="50" />
+```
+
+##### API
+
+Refer to the [PrimeVue ProgressBar API](https://primevue.org/progressbar/#api).

--- a/ui/src/components/ButtonMenu.vue
+++ b/ui/src/components/ButtonMenu.vue
@@ -1,0 +1,153 @@
+<template>
+    <div
+        v-bind="bindProps"
+        :class="mergedPt.root.class"
+        @mouseenter="onTriggerEnter"
+        @mouseleave="onTriggerLeave"
+    >
+        <template v-if="$slots.trigger">
+            <slot name="trigger" :toggleMenu="toggleMenu" :triggerRef="setTriggerRef" />
+        </template>
+        <template v-else>
+            <Button
+                v-if="!onHover"
+                ref="trigger"
+                :icon="icon"
+                text
+                size="small"
+                pt:root:class="!p-0 !w-[20px]"
+                @click="toggleMenu"
+            />
+            <Button
+                v-else
+                ref="trigger"
+                text
+                pt:root:class="!p-0 !w-[20px]"
+                @click="toggleMenu"
+            >
+                <IconChevronDown
+                    class="transition-transform duration-200"
+                    :class="isMenuOpen ? 'rotate-180' : ''"
+                />
+            </Button>
+        </template>
+        <Menu
+            ref="menu"
+            :model="items"
+            :popup="true"
+            :pt="mergedPt.menu"
+            @show="onMenuShow"
+            @hide="onMenuHide"
+            @mouseenter="onMenuEnter"
+            @mouseleave="onMenuLeave"
+        >
+            <template #item="{ item, props }">
+                <div
+                    v-bind="props.action"
+                    @click="actionClick(item)"
+                    :class="[
+                        'flex items-center px-3 py-2 text-sm',
+                        item.disabled
+                            ? 'opacity-50 cursor-not-allowed'
+                            : 'cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800',
+                        'text-surface-900 dark:text-surface-0 rounded-md'
+                    ]"
+                >
+                    <span v-if="item.icon" :class="item.icon" />
+                    <span class="ml-2">{{ item.label }}</span>
+                </div>
+            </template>
+        </Menu>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, useAttrs, computed } from 'vue';
+import Button from './Button.vue';
+import Menu from './Menu.vue';
+import { IconChevronDown } from '@tabler/icons-vue';
+import type { MenuItem } from 'primevue/menuitem';
+import { ptMerge } from '../utils';
+
+interface ButtonMenuPassThroughOptions {
+    root?: any;
+    menu?: any;
+}
+
+interface Props {
+    items?: MenuItem[];
+    icon?: string;
+    ptData?: Record<string, any>;
+    onHover?: boolean;
+    pt?: ButtonMenuPassThroughOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    icon: 'pi pi-ellipsis-v',
+    ptData: () => ({}),
+    onHover: false
+});
+const attrs = useAttrs();
+
+const theme = ref<ButtonMenuPassThroughOptions>({
+    root: 'relative flex justify-center',
+    menu: {}
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, items, icon, ptData, onHover, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
+const trigger = ref<any>(null);
+const menu = ref<any>(null);
+const isMenuOpen = ref(false);
+let closeTimeout = ref<any>(null);
+
+const setTriggerRef = (el: any) => {
+    trigger.value = el;
+};
+
+const getTriggerEl = () => trigger.value?.$el || trigger.value?.$refs?.button || trigger.value;
+
+const onTriggerEnter = async () => {
+    if (!props.onHover || isMenuOpen.value) return;
+    clearTimeout(closeTimeout.value);
+    await nextTick();
+    const el = getTriggerEl();
+    if (el) menu.value.show({ currentTarget: el });
+};
+
+const onTriggerLeave = () => {
+    if (!props.onHover) return;
+    closeTimeout.value = setTimeout(() => {
+        if (isMenuOpen.value) menu.value.hide();
+    }, 100);
+};
+
+const toggleMenu = () => {
+    const el = getTriggerEl();
+    if (el) menu.value.toggle({ currentTarget: el });
+};
+
+const onMenuShow = () => (isMenuOpen.value = true);
+const onMenuHide = () => (isMenuOpen.value = false);
+const onMenuEnter = () => clearTimeout(closeTimeout.value);
+const onMenuLeave = () => {
+    if (!props.onHover) return;
+    closeTimeout.value = setTimeout(() => {
+        if (isMenuOpen.value) menu.value.hide();
+    }, 100);
+};
+
+const actionClick = (item: any) => {
+    if (item?.disabled) return;
+    item?.click ? item.click() : emit('action', item.action, props.ptData);
+};
+
+const emit = defineEmits<{
+    (e: 'action', action: any, ptData: Record<string, any>): void;
+}>();
+</script>

--- a/ui/src/components/DatePicker.vue
+++ b/ui/src/components/DatePicker.vue
@@ -1,0 +1,227 @@
+<template>
+    <DatePicker
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #prevbutton="{ actionCallback, keydownCallback }">
+            <Button variant="text" rounded @click="actionCallback" @keydown="keydownCallback">
+                <template #icon>
+                    <ChevronLeftIcon />
+                </template>
+            </Button>
+        </template>
+        <template #nextbutton="{ actionCallback, keydownCallback }">
+            <Button variant="text" rounded @click="actionCallback" @keydown="keydownCallback">
+                <template #icon>
+                    <ChevronRightIcon />
+                </template>
+            </Button>
+        </template>
+        <template #todaybutton="{ actionCallback, keydownCallback }">
+            <Button variant="text" label="Today" size="small" @click="actionCallback" @keydown="keydownCallback" />
+        </template>
+        <template #clearbutton="{ actionCallback, keydownCallback }">
+            <Button variant="text" label="Clear" size="small" @click="actionCallback" @keydown="keydownCallback" />
+        </template>
+        <template #dropdownicon>
+            <ChevronDownIcon />
+        </template>
+        <template #inputicon>
+            <CalendarIcon />
+        </template>
+        <template #hourincrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronUpIcon />
+                </template>
+            </Button>
+        </template>
+        <template #hourdecrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronDownIcon />
+                </template>
+            </Button>
+        </template>
+        <template #minuteincrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronUpIcon />
+                </template>
+            </Button>
+        </template>
+        <template #minutedecrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronDownIcon />
+                </template>
+            </Button>
+        </template>
+        <template #secondincrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronUpIcon />
+                </template>
+            </Button>
+        </template>
+        <template #seconddecrementbutton="{ callbacks }">
+            <Button variant="text" rounded v-on="callbacks">
+                <template #icon>
+                    <ChevronDownIcon />
+                </template>
+            </Button>
+        </template>
+        <template #ampmincrementbutton="{ toggleCallback, keydownCallback }">
+            <Button variant="text" rounded @click="toggleCallback" @keydown="keydownCallback">
+                <template #icon>
+                    <ChevronUpIcon />
+                </template>
+            </Button>
+        </template>
+        <template #ampmdecrementbutton="{ toggleCallback, keydownCallback }">
+            <Button variant="text" rounded @click="toggleCallback" @keydown="keydownCallback">
+                <template #icon>
+                    <ChevronDownIcon />
+                </template>
+            </Button>
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </DatePicker>
+</template>
+
+<script setup lang="ts">
+import CalendarIcon from '@primevue/icons/calendar';
+import ChevronDownIcon from '@primevue/icons/chevrondown';
+import ChevronLeftIcon from '@primevue/icons/chevronleft';
+import ChevronRightIcon from '@primevue/icons/chevronright';
+import ChevronUpIcon from '@primevue/icons/chevronup';
+import DatePicker, { type DatePickerPassThroughOptions, type DatePickerProps } from 'primevue/datepicker';
+import { ref, useAttrs, computed } from 'vue';
+import Button from './Button.vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ DatePickerProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<DatePickerPassThroughOptions>({
+    root: `inline-flex max-w-full relative p-fluid:flex`,
+    pcInputText: {
+        root: `flex-auto w-[1%] appearance-none rounded-md outline-hidden
+        p-has-dropdown:rounded-e-none p-has-e-icon:pe-10
+        bg-surface-0 dark:bg-surface-950
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        text-surface-700 dark:text-surface-0
+        placeholder:text-surface-500 dark:placeholder:text-surface-400
+        border border-surface-300 dark:border-surface-700
+        enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+        enabled:focus:border-primary
+        disabled:bg-surface-200 disabled:text-surface-500
+        dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        p-invalid:placeholder:text-red-600 dark:p-invalid:placeholder:text-red-400
+        px-3 py-2 p-fluid:w-full
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+        transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
+    },
+    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-md
+        border border-s-0 border-surface-300 dark:border-surface-700
+        bg-surface-100 enabled:hover:bg-surface-200 enabled:active:bg-surface-300
+        text-surface-600 enabled:hover:text-surface-700 enabled:hover:active:text-surface-800
+        dark:bg-surface-800 dark:enabled:hover:bg-surface-700 dark:enabled:active:bg-surface-600
+        dark:text-surface-300 dark:enabled:hover:text-surface-200 dark:enabled:active:text-surface-100
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        transition-colors duration-200`,
+    inputIconContainer: `cursor-pointer absolute top-1/2 end-3 -mt-2 text-surface-400 leading-none p-small:*:size-[0.875rem] p-large:*:size-[1.125rem]`,
+    panel: `p-portal-self:min-w-full w-auto p-3 rounded-md
+        p-inline:inline-block p-inline:overflow-x-auto p-inline:shadow-none
+        border border-surface-200 dark:border-surface-700
+        bg-surface-0 dark:bg-surface-900
+        text-surface-700 dark:text-surface-0
+        shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
+    calendarContainer: `flex`,
+    calendar: `flex-auto border-s border-surface-200 dark:border-surface-700 gap-3 px-3
+        first:ps-0 first:border-s-0 last:pe-0`,
+    header: `flex items-center justify-between pt-0 px-0 pb-2 font-medium gap-2
+        bg-surface-0 dark:bg-surface-900
+        text-surface-700 dark:text-surface-0
+        border-b border-surface-200 dark:border-surface-700`,
+    title: `flex items-center justify-between gap-2 font-medium`,
+    selectMonth: `border-none bg-transparent m-0 cursor-pointer font-medium transition-colors duration-200
+        py-1 px-2 rounded-md text-surface-700 dark:text-surface-0
+        enabled:hover:bg-surface-100 enabled:hover:text-surface-800
+        dark:enabled:hover:bg-surface-800 dark:enabled:hover:text-surface-0
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`,
+    selectYear: `border-none bg-transparent m-0 cursor-pointer font-medium transition-colors duration-200
+        py-1 px-2 rounded-md text-surface-700 dark:text-surface-0
+        enabled:hover:bg-surface-100 enabled:hover:text-surface-800
+        dark:enabled:hover:bg-surface-800 dark:enabled:hover:text-surface-0
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`,
+    decade: `white-space-nowrap`,
+    dayView: `w-full border-collapse text-base mt-2 mx-0 mb-0`,
+    tableHeader: ``,
+    tableHeaderRow: ``,
+    weekHeader: `p-1`,
+    weekHeaderLabel: `font-medium text-surface-700 dark:text-surface-0 opacity-60`,
+    tableHeaderCell: ``,
+    weekDayCell: `p-1`,
+    weekDay: `font-medium text-surface-700 dark:text-surface-0`,
+    tableBody: ``,
+    weekNumber: ``,
+    weekLabelContainer: `opacity-60 flex w-8 h-8 p-1 justify-center`,
+    weekLabel: ``,
+    dayCell: `p-1`,
+    day: `flex items-center justify-center cursor-pointer my-0 mx-auto overflow-hidden relative w-8 h-8
+        rounded-full p-1 transition-colors duration-200 border border-transparent text-surface-700 dark:text-surface-0
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        p-disabled:opacity-60 p-disabled:pointer-events-none
+        hover:bg-surface-100 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-0
+        p-selected:bg-primary p-selected:text-primary-contrast
+        p-today:bg-surface-200 p-today:text-surface-900 dark:p-today:bg-surface-700 dark:p-today:text-surface-0
+        p-today:hover:bg-surface-100 p-today:hover:text-surface-800 dark:p-today:hover:bg-surface-800 dark:p-today:hover:text-surface-0
+        p-today:p-selected:bg-primary p-today:p-selected:text-primary-contrast`,
+    monthView: `mt-2 mb-0 mx-0`,
+    month: `w-1/3 inline-flex items-center justify-center cursor-pointer overflow-hidden relative
+        p-[0.375rem] transition-colors duration-200 rounded-md text-surface-700 dark:text-surface-0
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        hover:bg-surface-100 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-0
+        p-selected:bg-primary p-selected:text-primary-contrast`,
+    yearView: `mt-2 mb-0 mx-0`,
+    year: `w-1/2 inline-flex items-center justify-center cursor-pointer overflow-hidden relative
+        p-[0.375rem] transition-colors duration-200 rounded-md text-surface-700 dark:text-surface-0
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        hover:bg-surface-100 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-0
+        p-selected:bg-primary p-selected:text-primary-contrast`,
+    timePicker: `flex items-center justify-center border-t border-surface-200 dark:border-surface-700 p-0 gap-2
+        not-p-time-only:pt-2 not-p-time-only:pb-0 not-p-time-only:px-0`,
+    hourPicker: `flex items-center flex-col gap-1`,
+    hour: `text-base`,
+    separatorContainer: `flex items-center flex-col gap-1`,
+    separator: `text-base`,
+    minutePicker: `flex items-center flex-col gap-1`,
+    minute: `text-base`,
+    secondPicker: `flex items-center flex-col gap-1`,
+    second: `text-base`,
+    ampmPicker: `flex items-center flex-col gap-1`,
+    ampm: `text-base`,
+    buttonbar: `flex justify-between items-center pt-2 pb-0 px-0 border-t border-surface-200 dark:border-surface-700`,
+    transition: {
+        enterFromClass: 'opacity-0 scale-y-75',
+        enterActiveClass: 'transition duration-120 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-opacity duration-100 ease-linear',
+        leaveToClass: 'opacity-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/ProgressBar.vue
+++ b/ui/src/components/ProgressBar.vue
@@ -1,0 +1,75 @@
+<template>
+    <ProgressBar
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </ProgressBar>
+</template>
+
+<script setup lang="ts">
+import ProgressBar, { type ProgressBarPassThroughOptions, type ProgressBarProps } from 'primevue/progressbar';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ ProgressBarProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<ProgressBarPassThroughOptions>({
+    root: `relative overflow-hidden h-5 bg-surface-200 dark:bg-surface-700 rounded-md`,
+    value: `m-0 bg-primary
+        p-determinate:h-full p-determinate:w-0 p-determinate:absolute p-determinate:flex p-determinate:items-center p-determinate:justify-center
+        p-determinate:overflow-hidden p-determinate:transition-[width] p-determinate:duration-1000 p-determinate:ease-in-out
+        p-indeterminate:before:content-[''] p-indeterminate:before:absolute p-indeterminate:before:bg-inherit p-indeterminate:before:top-0 p-indeterminate:before:start-0 p-indeterminate:before:bottom-0 p-indeterminate:before:will-change-[inset-inline-start,inset-inline-end]
+        p-indeterminate:before:animate-[p-progressbar-indeterminate-anim_2.1s_cubic-bezier(0.65,0.815,0.735,0.395)_infinite]
+        p-indeterminate:after:content-[''] p-indeterminate:after:absolute p-indeterminate:after:bg-inherit p-indeterminate:after:top-0 p-indeterminate:after:start-0 p-indeterminate:after:bottom-0 p-indeterminate:after:will-change-[inset-inline-start,inset-inline-end]
+        p-indeterminate:after:animate-[p-progressbar-indeterminate-anim-short_2.1s_cubic-bezier(0.165,0.84,0.44,1)_infinite]
+        p-indeterminate:after:animate-delay-[1.15s]`,
+    label: `text-primary-contrast text-xs font-semibold
+        p-determinate:inline-flex`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, (props as any).pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>
+
+<style>
+@keyframes p-progressbar-indeterminate-anim {
+    0% {
+        inset-inline-start: -35%;
+        inset-inline-end: 100%;
+    }
+    60% {
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
+    }
+    100% {
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
+    }
+}
+
+@keyframes p-progressbar-indeterminate-anim-short {
+    0% {
+        inset-inline-start: -200%;
+        inset-inline-end: 100%;
+    }
+    60% {
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
+    }
+    100% {
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
+    }
+}
+</style>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -42,3 +42,6 @@ export { default as Slider } from './Slider.vue';
 export { default as Password } from './Password.vue';
 export { default as Paginator } from './Paginator.vue';
 export { default as Pagination } from './Pagination.vue';
+export { default as ProgressBar } from './ProgressBar.vue';
+export { default as ButtonMenu } from './ButtonMenu.vue';
+export { default as DatePicker } from './DatePicker.vue';


### PR DESCRIPTION
## Summary
- add ProgressBar component with passthrough styling
- introduce ButtonMenu for triggerable menu actions
- wrap PrimeVue DatePicker with Atlas styles and small button controls
- document ProgressBar, ButtonMenu, and DatePicker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a907339ad08325966d5774e3a7ca44