### PR TITLE
Ensure JSON caster returns decoded arrays

### DIFF
--- a/laravel/src/Support/Caster.php
+++ b/laravel/src/Support/Caster.php
@@ -59,15 +59,22 @@ class Caster
     }
 
     /**
-     * Cast a value to JSON string or object.
+     * Cast a value to a decoded JSON representation.
+     *
+     * Arrays or objects are converted to JSON and then decoded so that the
+     * return value is always a PHP array (or scalar) rather than a JSON string.
      *
      * @param mixed $value The value to cast.
-     * @return mixed The cast JSON value.
+     * @return mixed The decoded JSON value or null on failure.
      */
     private static function castToJson(mixed $value): mixed
     {
         if (is_array($value) || is_object($value)) {
-            return json_encode($value);
+            $value = json_encode($value);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return null;
+            }
         }
 
         $decoded = json_decode($value, true);

--- a/laravel/tests/Support/CasterTest.php
+++ b/laravel/tests/Support/CasterTest.php
@@ -17,6 +17,7 @@ class CasterTest extends TestCase
             'options' => '{"foo":"bar"}',
             'birthday' => '2024-01-01',
             'meta' => ['foo' => 'bar'],
+            'metaObject' => (object) ['foo' => 'bar'],
             'invalidDate' => 'not-a-date',
             'invalidJson' => '{bad json',
         ];
@@ -29,6 +30,7 @@ class CasterTest extends TestCase
             'options' => 'json',
             'birthday' => 'datetime',
             'meta' => 'json',
+            'metaObject' => 'json',
             'invalidDate' => 'datetime',
             'invalidJson' => 'json',
         ];
@@ -41,7 +43,8 @@ class CasterTest extends TestCase
         $this->assertTrue($result['active']);
         $this->assertSame(['foo' => 'bar'], $result['options']);
         $this->assertInstanceOf(\DateTime::class, $result['birthday']);
-        $this->assertSame(json_encode(['foo' => 'bar']), $result['meta']);
+        $this->assertSame(['foo' => 'bar'], $result['meta']);
+        $this->assertSame(['foo' => 'bar'], $result['metaObject']);
         $this->assertNull($result['invalidDate']);
         $this->assertNull($result['invalidJson']);
     }


### PR DESCRIPTION
## Summary
- Normalize Caster::castToJson to always output decoded arrays
- Adjust Caster tests for array and object inputs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a90c24ee488325b47415ff91379d69