### PR TITLE
feat: add page activity utility and Topbar component

### DIFF
--- a/docs/ui/utils.md
+++ b/docs/ui/utils.md
@@ -21,6 +21,7 @@
   - [isClient](#isclient)
   - [getRandomItem](#getrandomitem)
   - [roundTo](#roundto)
+  - [isPageActive](#ispageactive)
 
 ## Format Utilities
 
@@ -347,4 +348,24 @@ import { roundTo } from '@tmarois/atlas';
 
 roundTo(1.005, 2); // 1.01
 roundTo(123.456, 1); // 123.5
+```
+
+### isPageActive
+
+Determines whether the current Inertia page URL matches a given path.
+
+**Parameters:**
+- `itemPath` (string): The path to compare against the current page URL.
+- `itemParent` (string, optional): Parent path that overrides `itemPath`.
+- `eq` (boolean, optional): If true, requires an exact match; otherwise checks that the current path starts with the route path.
+
+**Returns:** Boolean indicating whether the current page is active.
+
+**Example:**
+```typescript
+import { isPageActive } from '@tmarois/atlas';
+
+isPageActive('/users'); // true when current URL begins with '/users'
+isPageActive('/users', undefined, true); // true only when URL is exactly '/users'
+isPageActive('/profile', '/users'); // checks against '/users'
 ```

--- a/ui/src/components/App/Topbar.vue
+++ b/ui/src/components/App/Topbar.vue
@@ -1,0 +1,34 @@
+<template>
+    <div v-bind="bindProps" :class="mergedPt.root.class">
+        <slot />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+import { ptMerge } from '../../utils';
+
+interface TopbarPassThroughOptions {
+    root?: any;
+}
+
+interface Props {
+    pt?: TopbarPassThroughOptions;
+}
+
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = computed<TopbarPassThroughOptions>(() => ({
+    root: 'h-[56px] bg-white border-b border-surface-300 dark:bg-surface-800 dark:border-surface-700 flex items-center w-full'
+}));
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -50,3 +50,4 @@ export { default as EditorContent } from './Editor/EditorContent.vue';
 export { default as Table } from './App/Table/Table.vue';
 export { default as TableActions } from './App/Table/Actions.vue';
 export { default as TableCustomizeColumns } from './App/Table/CustomizeColumns.vue';
+export { default as Topbar } from './App/Topbar.vue';

--- a/ui/src/utils/vue/index.ts
+++ b/ui/src/utils/vue/index.ts
@@ -1,3 +1,4 @@
 export * from './ptViewMerge';
 export * from './hasSlotContent';
 export * from './ptMerge';
+export * from './isPageActive';

--- a/ui/src/utils/vue/isPageActive.ts
+++ b/ui/src/utils/vue/isPageActive.ts
@@ -1,0 +1,24 @@
+import { usePage } from '@inertiajs/vue3';
+
+/**
+ * Determine whether the current Inertia page is active.
+ *
+ * @param itemPath - Path to compare against the current page URL.
+ * @param itemParent - Optional parent path that overrides itemPath.
+ * @param eq - When true, requires an exact match instead of a "startsWith" comparison.
+ * @returns True if the current page matches the given path.
+ */
+export const isPageActive = (
+    itemPath: string,
+    itemParent?: string,
+    eq = false
+): boolean => {
+    const page = usePage();
+    const path = itemParent ?? itemPath;
+    const currentPath = new URL(page.url, document.baseURI).pathname;
+    const routePath = new URL(path, document.baseURI).pathname;
+
+    return eq ? currentPath === routePath : currentPath.startsWith(routePath);
+};
+
+export default isPageActive;

--- a/ui/tests/utils/vue/isPageActive.test.ts
+++ b/ui/tests/utils/vue/isPageActive.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+
+let mockUrl = '/users/1';
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ url: mockUrl })
+}));
+
+import { isPageActive } from '../../../src/utils';
+
+describe('isPageActive', () => {
+    it('returns true when current path starts with route', () => {
+        mockUrl = '/users/1';
+        expect(isPageActive('/users')).toBe(true);
+    });
+
+    it('requires exact match when eq is true', () => {
+        mockUrl = '/users';
+        expect(isPageActive('/users', undefined, true)).toBe(true);
+        mockUrl = '/users/1';
+        expect(isPageActive('/users', undefined, true)).toBe(false);
+    });
+
+    it('uses parent path when provided', () => {
+        mockUrl = '/users/1';
+        expect(isPageActive('/child', '/users')).toBe(true);
+    });
+
+    it('returns false when paths do not match', () => {
+        mockUrl = '/users';
+        expect(isPageActive('/settings')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- add `isPageActive` helper for Inertia page checks
- document `isPageActive` utility
- add `Topbar` component with pass-through support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a931b7c3bc8325979bdd2fd349cbb8