### PR TITLE
fix: isolate component imports in tests

### DIFF
--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
-import { Button } from '../../src/components';
+import Button from '../../src/components/Button.vue';
 
 const mountWithPrime = (props: any = {}) =>
     mount(Button, {

--- a/ui/tests/components/Errors.test.ts
+++ b/ui/tests/components/Errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { Errors } from '../../src/components';
+import Errors from '../../src/components/Errors.vue';
 
 describe('Errors', () => {
     it('renders provided errors', () => {

--- a/ui/tests/components/ptMerge.test.ts
+++ b/ui/tests/components/ptMerge.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
-import { Alert, Button, Card, Checkbox, InputMask, InputNumber, InputText, Select, Textarea } from '../../src/components';
+import Alert from '../../src/components/Alert.vue';
+import Button from '../../src/components/Button.vue';
+import Card from '../../src/components/Card.vue';
+import Checkbox from '../../src/components/Checkbox.vue';
+import InputMask from '../../src/components/InputMask.vue';
+import InputNumber from '../../src/components/InputNumber.vue';
+import InputText from '../../src/components/InputText.vue';
+import Select from '../../src/components/Select.vue';
+import Textarea from '../../src/components/Textarea.vue';
 
 Object.defineProperty(window, 'matchMedia', {
     writable: true,


### PR DESCRIPTION
## Summary
- fix unit tests by importing Vue components individually to avoid missing `@tiptap/vue-3` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9367e8d1c83258c07cdf16e87376d