### PR TITLE
feat(ui): add TooltipInfo component

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -58,6 +58,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Chip](#chip)
   - [Badge](#badge)
   - [TooltipIcon](#tooltipicon)
+  - [TooltipInfo](#tooltipinfo)
 - [Navigation](#navigation)
   - [ButtonMenu](#buttonmenu)
   - [Menu](#menu)
@@ -581,6 +582,29 @@ import { TooltipIcon } from '@atlas/ui';
 
 - `text` – tooltip text displayed on hover.
 - `pt` – passthrough options to customize internal elements.
+
+#### TooltipInfo
+```ts
+import { TooltipInfo } from '@atlas/ui';
+```
+
+```vue
+<TooltipInfo>
+    Details here
+</TooltipInfo>
+```
+
+##### Props
+
+- `iconClass` – class for the info icon. Defaults to 'size-5'.
+
+##### Events
+
+- `toggle` – emitted with the visibility state when the popover is toggled.
+
+##### Slots
+
+- `default` – content displayed inside the popover.
 
 ### Navigation
 

--- a/ui/src/components/TooltipInfo.vue
+++ b/ui/src/components/TooltipInfo.vue
@@ -1,0 +1,60 @@
+<template>
+    <div
+        class="relative hover:cursor-pointer text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+        :class="{ 'text-primary-500 hover:text-primary-600 dark:text-gray-200': isActive }"
+        @click="toggle"
+    >
+        <svg
+            v-show="isActive"
+            xmlns="http://www.w3.org/2000/svg"
+            :class="iconClass"
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+            />
+        </svg>
+        <svg
+            v-show="!isActive"
+            xmlns="http://www.w3.org/2000/svg"
+            :class="iconClass"
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8"
+            />
+        </svg>
+    </div>
+    <Popover ref="tactive" @show="setIsActive(true)" @hide="setIsActive(false)">
+        <slot />
+    </Popover>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import Popover from './Popover.vue';
+
+interface Props {
+    iconClass?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    iconClass: 'size-5'
+});
+
+const emit = defineEmits<{ (e: 'toggle', value: boolean): void }>();
+
+const isActive = ref(false);
+const tactive = ref<any>();
+
+const setIsActive = (value: boolean) => {
+    isActive.value = value;
+    emit('toggle', isActive.value);
+};
+
+const toggle = (event: any) => {
+    tactive.value.toggle(event);
+};
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -30,6 +30,7 @@ export { default as LabelField } from './LabelField.vue';
 export { default as Popover } from './Popover.vue';
 export { default as RadioButton } from './RadioButton.vue';
 export { default as TooltipIcon } from './TooltipIcon.vue';
+export { default as TooltipInfo } from './TooltipInfo.vue';
 export { default as Toast } from './Toast.vue';
 export { default as ToggleButton } from './ToggleButton.vue';
 export { default as ToggleSwitch } from './ToggleSwitch.vue';


### PR DESCRIPTION
## Summary
- add TooltipInfo component for popover-based info icons
- document TooltipInfo in UI guide

## Testing
- `npm test` (fails: Failed to resolve import "@atlas/components/ScrollFrame.vue" from "src/components/App/Page/Content.vue")

------
https://chatgpt.com/codex/tasks/task_b_68a936aafc3c8325a16ee1165b76b38f