### PR TITLE
feat: add nav topbar & sidebar components

### DIFF
--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="relative dark flex flex-col items-center w-16 h-full overflow-hidden text-white/80 bg-surface-800 border-r border-surface-700 z-[99]">
+        <component :is="linkComponent" class="flex items-center justify-center h-14" :href="homeUrl">
+            <div class="flex-shrink-0">
+                <slot name="logo">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-8 w-8"
+                        viewBox="0 0 256 264"
+                    ><path
+                        fill="#ff2d20"
+                        d="M255.856 59.62c.095.351.144.713.144 1.077v56.568c0 1.478-.79 2.843-2.073 3.578L206.45 148.18v54.18a4.14 4.14 0 0 1-2.062 3.579l-99.108 57.053c-.227.128-.474.21-.722.299c-.093.03-.18.087-.278.113a4.15 4.15 0 0 1-2.114 0c-.114-.03-.217-.093-.325-.134c-.227-.083-.464-.155-.68-.278L2.073 205.938A4.13 4.13 0 0 1 0 202.36V32.656c0-.372.052-.733.144-1.083c.031-.119.103-.227.145-.346c.077-.216.15-.438.263-.639c.077-.134.19-.242.283-.366c.119-.165.227-.335.366-.48c.119-.118.274-.206.408-.309c.15-.124.283-.258.453-.356h.005L51.613.551a4.14 4.14 0 0 1 4.125 0l49.546 28.526h.01c.165.104.305.232.454.351c.134.103.284.196.402.31c.145.149.248.32.371.484c.088.124.207.232.279.366c.118.206.185.423.268.64c.041.118.113.226.144.35c.095.351.144.714.145 1.078V138.65l41.286-23.773V60.692c0-.36.052-.727.145-1.072c.036-.124.103-.232.144-.35c.083-.217.155-.44.268-.64c.077-.134.19-.242.279-.366c.123-.165.226-.335.37-.48c.12-.118.269-.206.403-.309c.155-.124.289-.258.454-.356h.005l49.551-28.526a4.13 4.13 0 0 1 4.125 0l49.546 28.526c.175.103.309.232.464.35c.128.104.278.197.397.31c.144.15.247.32.37.485c.094.124.207.232.28.366c.118.2.185.423.267.64c.047.118.114.226.145.35m-8.115 55.258v-47.04l-17.339 9.981l-23.953 13.792v47.04l41.297-23.773zm-49.546 85.095V152.9l-23.562 13.457l-67.281 38.4v47.514zM8.259 39.796v160.177l90.833 52.294v-47.505L51.64 177.906l-.015-.01l-.02-.01c-.16-.093-.295-.227-.444-.34c-.13-.104-.279-.186-.392-.3l-.01-.015c-.134-.129-.227-.289-.34-.433c-.104-.14-.227-.258-.31-.402l-.005-.016c-.093-.154-.15-.34-.217-.515c-.067-.155-.154-.3-.196-.464v-.005c-.051-.196-.061-.403-.082-.604c-.02-.154-.062-.309-.062-.464V63.57L25.598 49.772l-17.339-9.97zM53.681 8.893L12.399 32.656l41.272 23.762L94.947 32.65L53.671 8.893zm21.468 148.298l23.948-13.786V39.796L81.76 49.778L57.805 63.569v103.608zM202.324 36.935l-41.276 23.762l41.276 23.763l41.271-23.768zm-4.13 54.676l-23.953-13.792l-17.338-9.981v47.04l23.948 13.787l17.344 9.986zm-94.977 106.006l60.543-34.564l30.264-17.272l-41.246-23.747l-47.489 27.34l-43.282 24.918z"
+                    /></svg>
+                </slot>
+            </div>
+        </component>
+        <div class="flex flex-col flex-1 items-center justify-between w-full px-2">
+            <div class="flex-1 flex flex-col items-center w-full overflow-y-auto">
+                <template v-for="(item, itemIndex) in items" :key="itemIndex">
+                    <div
+                        class="flex flex-col items-center justify-start w-full"
+                        :class="{ 'border-t border-surface-600 mt-2': itemIndex !== 0 }"
+                    >
+                        <template v-for="(child, index) in item.children" :key="index">
+                            <component
+                                v-if="child.href"
+                                :is="linkComponent"
+                                v-tooltip.right="{
+                                    value: child.label,
+                                    pt: {
+                                        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px] ml-3',
+                                        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+                                    }
+                                }"
+                                class="relative flex items-center justify-center w-full h-12 mt-2 rounded hover:bg-surface-600 text-white"
+                                :href="child.href"
+                                :class="{ 'bg-surface-500/80': isActive(child) }"
+                            >
+                                <component :is="getIcon(child)" />
+                                <div
+                                    v-if="child?.count > 0"
+                                    class="absolute top-2 right-2 flex items-center justify-center text-xs font-semibold text-white bg-red-500 rounded-full transform translate-x-1/4 -translate-y-1/2 min-w-[26px] px-1 h-[20px] border-2 border-surface-800 z-[99]"
+                                >
+                                    <span v-if="child.count > 99">99+</span>
+                                    <span v-else>{{ child.count }}</span>
+                                </div>
+                            </component>
+                        </template>
+                    </div>
+                </template>
+            </div>
+            <div v-if="hasActions" class="w-full mb-2 flex flex-col items-center space-y-2">
+                <slot name="actions" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+import { hasSlotContent, isPageActive } from '../../../utils';
+
+const slots = useSlots();
+
+const props = defineProps({
+    items: {
+        type: Array,
+        required: true
+    },
+    homeUrl: {
+        type: String,
+        default: '/'
+    },
+    linkComponent: {
+        type: [String, Object],
+        default: 'a'
+    }
+});
+
+const isActive = (item) => {
+    if (item.parent) {
+        return isPageActive(item.parent);
+    }
+    if (item.href === '/') {
+        return isPageActive(item.href, undefined, true);
+    }
+    return isPageActive(item.href);
+};
+
+const getIcon = (item) => {
+    return isActive(item) && item.activeIcon ? item.activeIcon : item.icon;
+};
+
+const hasActions = computed(() => hasSlotContent(slots.actions));
+</script>

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -1,0 +1,123 @@
+<template>
+    <nav class="w-full dark bg-surface-800 border-b border-surface-700 shadow-lg">
+        <div class="mx-auto px-4" :class="widthClass">
+            <div class="flex h-16 items-center justify-between">
+                <div class="flex items-center">
+                    <div class="flex-shrink-0">
+                        <component :is="linkComponent" :href="homeUrl" class="inline-flex items-center h-8">
+                            <slot name="logo">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="h-8 w-8"
+                                    viewBox="0 0 256 264"
+                                ><path
+                                    fill="#ff2d20"
+                                    d="M255.856 59.62c.095.351.144.713.144 1.077v56.568c0 1.478-.79 2.843-2.073 3.578L206.45 148.18v54.18a4.14 4.14 0 0 1-2.062 3.579l-99.108 57.053c-.227.128-.474.21-.722.299c-.093.03-.18.087-.278.113a4.15 4.15 0 0 1-2.114 0c-.114-.03-.217-.093-.325-.134c-.227-.083-.464-.155-.68-.278L2.073 205.938A4.13 4.13 0 0 1 0 202.36V32.656c0-.372.052-.733.144-1.083c.031-.119.103-.227.145-.346c.077-.216.15-.438.263-.639c.077-.134.19-.242.283-.366c.119-.165.227-.335.366-.48c.119-.118.274-.206.408-.309c.15-.124.283-.258.453-.356h.005L51.613.551a4.14 4.14 0 0 1 4.125 0l49.546 28.526h.01c.165.104.305.232.454.351c.134.103.284.196.402.31c.145.149.248.32.371.484c.088.124.207.232.279.366c.118.206.185.423.268.64c.041.118.113.226.144.35c.095.351.144.714.145 1.078V138.65l41.286-23.773V60.692c0-.36.052-.727.145-1.072c.036-.124.103-.232.144-.35c.083-.217.155-.44.268-.64c.077-.134.19-.242.279-.366c.123-.165.226-.335.37-.48c.12-.118.269-.206.403-.309c.155-.124.289-.258.454-.356h.005l49.551-28.526a4.13 4.13 0 0 1 4.125 0l49.546 28.526c.175.103.309.232.464.35c.128.104.278.197.397.31c.144.15.247.32.37.485c.094.124.207.232.28.366c.118.2.185.423.267.64c.047.118.114.226.145.35m-8.115 55.258v-47.04l-17.339 9.981l-23.953 13.792v47.04l41.297-23.773zm-49.546 85.095V152.9l-23.562 13.457l-67.281 38.4v47.514zM8.259 39.796v160.177l90.833 52.294v-47.505L51.64 177.906l-.015-.01l-.02-.01c-.16-.093-.295-.227-.444-.34c-.13-.104-.279-.186-.392-.3l-.01-.015c-.134-.129-.227-.289-.34-.433c-.104-.14-.227-.258-.31-.402l-.005-.016c-.093-.154-.15-.34-.217-.515c-.067-.155-.154-.3-.196-.464v-.005c-.051-.196-.061-.403-.082-.604c-.02-.154-.062-.309-.062-.464V63.57L25.598 49.772l-17.339-9.97zM53.681 8.893L12.399 32.656l41.272 23.762L94.947 32.65L53.671 8.893zm21.468 148.298l23.948-13.786V39.796L81.76 49.778L57.805 63.569v103.608zM202.324 36.935l-41.276 23.762l41.276 23.763l41.271-23.768zm-4.13 54.676l-23.953-13.792l-17.338-9.981v47.04l23.948 13.787l17.344 9.986zm-94.977 106.006l60.543-34.564l30.264-17.272l-41.246-23.747l-47.489 27.34l-43.282 24.918z"
+                                /></svg>
+                            </slot>
+                        </component>
+                    </div>
+                    <div class="hidden md:flex ml-10 items-baseline space-x-4">
+                        <template v-for="item in items" :key="item.href">
+                            <component
+                                v-if="!item.children"
+                                :is="linkComponent"
+                                :href="item.href"
+                                class="rounded-md px-3 py-2 text-sm font-medium"
+                                :class="[
+                                    isActive(item)
+                                        ? 'bg-surface-900 text-white'
+                                        : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+                                ]"
+                            >
+                                {{ item.label }}
+                            </component>
+                            <div
+                                v-else
+                                class="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white cursor-pointer"
+                                :class="{ 'bg-surface-900 text-white': isActive(item) }"
+                                @click="toggleMenu(item.href, $event)"
+                            >
+                                {{ item.label }}
+                                <span class="pi pi-fw pi-angle-down ml-2" />
+                                <Menu
+                                    :ref="setMenuRef(item.href)"
+                                    :model="item.children"
+                                    popup
+                                >
+                                    <template #item="{ item, props }">
+                                        <component
+                                            :is="linkComponent"
+                                            v-bind="props.action"
+                                            :href="item.href"
+                                            class="flex items-center w-full px-2 py-1 text-sm rounded"
+                                            :class="{
+                                                'bg-surface-200 dark:bg-surface-800 dark:text-white': isActive(item)
+                                            }"
+                                        >
+                                            <span :class="item.icon" />
+                                            <span class="ml-2">{{ item.label }}</span>
+                                        </component>
+                                    </template>
+                                </Menu>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                <div v-if="hasActions" class="relative flex space-x-2 items-center">
+                    <slot name="actions" />
+                </div>
+            </div>
+        </div>
+    </nav>
+</template>
+
+<script setup>
+import { reactive, useSlots, computed } from 'vue';
+import { hasSlotContent, isPageActive } from '../../../utils';
+import Menu from '../../Menu.vue';
+
+const slots = useSlots();
+
+const props = defineProps({
+    items: {
+        type: Array,
+        required: true,
+    },
+    linkComponent: {
+        type: [String, Object],
+        default: 'a',
+    },
+    homeUrl: {
+        type: String,
+        default: '/',
+    },
+    widthClass: {
+        type: String,
+        default: 'max-w-screen-2xl',
+    }
+});
+
+const menuRefs = reactive({});
+
+const setMenuRef = (key) => (el) => {
+    if (el) menuRefs[key] = el;
+};
+
+const toggleMenu = (key, event) => {
+    const menu = menuRefs[key];
+    if (menu) menu.toggle(event);
+};
+
+const isActive = (item) => {
+    if (item.parent) {
+        return isPageActive(item.parent);
+    }
+    if (item.href === '/') {
+        return isPageActive(item.href, undefined, true);
+    }
+    return isPageActive(item.href);
+};
+
+const hasActions = computed(() => hasSlotContent(slots.actions));
+</script>

--- a/ui/src/components/App/Page/Content.vue
+++ b/ui/src/components/App/Page/Content.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue';
-import ScrollFrame from '@atlas/components/ScrollFrame.vue';
+import ScrollFrame from '../../ScrollFrame.vue';
 
 interface Props {
     offset?: number | null;

--- a/ui/src/components/App/Page/Footer.vue
+++ b/ui/src/components/App/Page/Footer.vue
@@ -19,7 +19,7 @@
 
 <script setup lang="ts">
 import { useSlots, computed } from 'vue';
-import { hasSlotContent } from '@atlas/utils';
+import { hasSlotContent } from '../../../utils';
 
 interface Props {
     leftOffset?: number;

--- a/ui/src/components/App/Page/Header.vue
+++ b/ui/src/components/App/Page/Header.vue
@@ -94,8 +94,8 @@
 <script setup lang="ts">
 import { computed, useSlots } from 'vue';
 import { IconLock } from '@tabler/icons-vue';
-import { useScroll } from '@atlas/composables/useScroll';
-import { hasSlotContent, isPageActive } from '@atlas/utils';
+import { useScroll } from '../../../composables/useScroll';
+import { hasSlotContent, isPageActive } from '../../../utils';
 
 interface Breadcrumb {
     href: string;

--- a/ui/src/components/App/Page/SideContent.vue
+++ b/ui/src/components/App/Page/SideContent.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script setup lang="ts">
-import ScrollFrame from '@atlas/components/ScrollFrame.vue';
+import ScrollFrame from '../../ScrollFrame.vue';
 </script>

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -47,8 +47,8 @@
 </template>
 
 <script setup lang="ts">
-import ScrollFrame from '@atlas/components/ScrollFrame.vue';
-import { isPageActive } from '@atlas/utils';
+import ScrollFrame from '../../ScrollFrame.vue';
+import { isPageActive } from '../../../utils';
 
 interface NavItem {
     label: string;

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -52,6 +52,8 @@ export { default as PageFooter } from './App/Page/Footer.vue';
 export { default as PageHeader } from './App/Page/Header.vue';
 export { default as PageSideContent } from './App/Page/SideContent.vue';
 export { default as PageSideNav } from './App/Page/SideNav.vue';
+export { default as NavSidebar } from './App/Nav/Sidebar.vue';
+export { default as NavTopbar } from './App/Nav/Topbar.vue';
 export { default as Table } from './App/Table/Table.vue';
 export { default as TableActions } from './App/Table/Actions.vue';
 export { default as TableCustomizeColumns } from './App/Table/CustomizeColumns.vue';


### PR DESCRIPTION
## Summary
- add NavTopbar and NavSidebar components using `isPageActive`
- export new components
- remove `@atlas` alias in components and test config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a936304abc83259931774402ac6a26