### PR TITLE
feat: add Dialog component

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -49,6 +49,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Accordion](#accordion)
   - [Card](#card)
   - [Divider](#divider)
+  - [Dialog](#dialog)
   - [Popover](#popover)
   - [Tabs](#tabs)
 - [Data Display](#data-display)
@@ -456,6 +457,24 @@ import { Divider } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).
+
+#### Dialog
+```ts
+import { Dialog, Button } from '@atlas/ui';
+```
+
+```vue
+<Dialog v-model:visible="visible">
+  Content
+  <template #footer>
+    <Button label="Close" @click="visible = false" />
+  </template>
+</Dialog>
+```
+
+##### API
+
+Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).
 
 #### Popover
 ```ts

--- a/ui/src/components/Dialog.vue
+++ b/ui/src/components/Dialog.vue
@@ -1,0 +1,69 @@
+<template>
+    <Dialog
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #closebutton="{ closeCallback }">
+            <Button text rounded @click="closeCallback" autofocus>
+                <template #icon>
+                    <TimesIcon />
+                </template>
+            </Button>
+        </template>
+        <template #maximizebutton="{ maximized, maximizeCallback }">
+            <Button text rounded @click="maximizeCallback" autofocus>
+                <template #icon>
+                    <WindowMinimizeIcon v-if="maximized" />
+                    <WindowMaximizeIcon v-else />
+                </template>
+            </Button>
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Dialog>
+</template>
+
+<script setup lang="ts">
+import TimesIcon from '@primevue/icons/times';
+import WindowMaximizeIcon from '@primevue/icons/windowmaximize';
+import WindowMinimizeIcon from '@primevue/icons/windowminimize';
+import Dialog, { type DialogPassThroughOptions, type DialogProps } from 'primevue/dialog';
+import { ref, useAttrs, computed } from 'vue';
+import Button from './Button.vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ DialogProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<DialogPassThroughOptions>({
+    root: `max-h-[90%] max-w-screen rounded-md
+        border border-surface-200 dark:border-surface-700
+        bg-surface-0 dark:bg-surface-900
+        text-surface-700 dark:text-surface-0 shadow-lg
+        p-maximized:w-screen p-maximized:h-screen p-maximized:top-0 p-maximized:start-0 p-maximized:max-h-full p-maximized:rounded-none`,
+    header: `flex items-center justify-between shrink-0 p-4 pt-2`,
+    title: `font-semibold text-lg`,
+    headerActions: `flex items-center gap-2`,
+    content: `overflow-y-auto pt-0 px-4 pb-4 p-maximized:grow`,
+    footer: `shrink-0 pt-0 px-4 pb-4 flex justify-end gap-2`,
+    mask: `p-modal:bg-black/50 p-modal:fixed p-modal:top-0 p-modal:start-0 p-modal:w-full p-modal:h-full`,
+    transition: {
+        enterFromClass: 'opacity-0 scale-75',
+        enterActiveClass: 'transition-all duration-150 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-all duration-150 ease-[cubic-bezier(0.4,0,0.2,1)]',
+        leaveToClass: 'opacity-0 scale-75'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -16,6 +16,7 @@ export { default as AvatarGroup } from './AvatarGroup.vue';
 export { default as Badge } from './Badge.vue';
 export { default as Chip } from './Chip.vue';
 export { default as DataTable } from './DataTable.vue';
+export { default as Dialog } from './Dialog.vue';
 export { default as Divider } from './Divider.vue';
 export { default as ScrollFrame } from './ScrollFrame.vue';
 export { default as Accordion } from './Accordion.vue';


### PR DESCRIPTION
## Summary
- add Dialog wrapper component with passthrough support
- export Dialog and document usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9380106308325b0010cadfe2863c7