### PR TITLE
feat(ui): add drawer components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -50,6 +50,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Card](#card)
   - [Divider](#divider)
   - [Dialog](#dialog)
+  - [Drawer](#drawer)
+  - [DrawerForm](#drawerform)
   - [Popover](#popover)
   - [Tabs](#tabs)
 - [Data Display](#data-display)
@@ -475,6 +477,48 @@ import { Dialog, Button } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).
+
+#### Drawer
+```ts
+import { Drawer } from '@atlas/ui';
+```
+
+```vue
+<Drawer v-model:visible="visible">
+  Content
+</Drawer>
+```
+
+##### API
+
+Refer to the [PrimeVue Drawer API](https://primevue.org/drawer/#api).
+
+#### DrawerForm
+```ts
+import { DrawerForm } from '@atlas/ui';
+```
+
+```vue
+<DrawerForm v-model="open" title="Title" @submit="save">
+  <!-- form fields -->
+</DrawerForm>
+```
+
+##### Props
+
+- `modelValue` – controls visibility.
+- `title` – header text.
+- `loading` – shows loading state on save.
+- `width` – optional width of drawer.
+- `errors` – form error object.
+- `tabs` – array of tab definitions.
+- `modelActiveTab` – active tab index.
+
+##### Events
+
+- `update:modelValue` – emitted when visibility changes.
+- `submit` – emitted on save.
+- `update:modelActiveTab` – emitted when active tab changes.
 
 #### Popover
 ```ts

--- a/ui/src/components/Drawer.vue
+++ b/ui/src/components/Drawer.vue
@@ -1,0 +1,70 @@
+<template>
+    <Drawer
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{
+            mergeProps: ptViewMerge
+        }"
+    >
+        <template #closebutton="{ closeCallback }">
+            <Button text rounded @click="closeCallback" autofocus>
+                <template #icon>
+                    <TimesIcon />
+                </template>
+            </Button>
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Drawer>
+</template>
+
+<script setup lang="ts">
+import TimesIcon from '@primevue/icons/times';
+import Drawer, { type DrawerPassThroughOptions, type DrawerProps } from 'primevue/drawer';
+import { ref, useAttrs, computed } from 'vue';
+import Button from './Button.vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ DrawerProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<DrawerPassThroughOptions>({
+    root: `atlas_drawer_shadow flex flex-col pointer-events-auto relative
+        border-surface-200 dark:border-surface-700
+        bg-surface-0 dark:bg-surface-900
+        text-surface-700 dark:text-surface-0
+        p-left:w-80 p-left:h-full p-left:border-r
+        p-right:w-80 p-right:h-full p-right:border-s
+        p-top:h-40 p-top:w-full p-top:border-b
+        p-bottom:h-40 p-bottom:w-full p-bottom:border-t
+        p-full-screen:transition-opacity p-full-screen:transform-none p-full-screen:w-screen p-full-screen:h-screen p-full-screen:max-h-full p-full-screen:top-0 p-full-screen:left-0`,
+    header: `flex items-center justify-between flex-shrink-0 p-5`,
+    title: `font-semibold text-2xl`,
+    content: `overflow-y-auto flex-grow pt-0 pb-5 px-5`,
+    footer: `p-5`,
+    mask: `p-modal:bg-black/30`,
+    transition: {
+        enterFromClass: `p-left:-translate-x-full p-right:translate-x-full p-top:-translate-y-full p-bottom:translate-y-full p-full-screen:opacity-0`,
+        enterActiveClass: `transition-transform duration-400 ease-out p-full-screen:transition-opacity`,
+        leaveActiveClass: `transition-transform duration-200 ease-in p-full-screen:transition-opacity`,
+        leaveToClass: `p-left:-translate-x-full p-right:translate-x-full p-top:-translate-y-full p-bottom:translate-y-full p-full-screen:opacity-0`
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, (props as any).pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>
+
+<style>
+.atlas_drawer_shadow {
+    box-shadow: 0 8px 10px -5px rgba(0, 0, 0, .2), 0 16px 24px 2px rgba(0, 0, 0, .14), 0 6px 30px 5px rgba(0, 0, 0, .12) !important;
+}
+</style>
+

--- a/ui/src/components/DrawerForm.vue
+++ b/ui/src/components/DrawerForm.vue
@@ -1,0 +1,101 @@
+<template>
+    <Drawer
+        :visible="modelValue"
+        position="right"
+        blockScroll
+        :style="width ? `width: ${width}; max-width: 100%;` : ''"
+        pt:root:class="p-right:lg:w-[60%] p-right:md:w-[80%] p-right:sm:w-[90%] p-right:w-full"
+        pt:mask:class="p-modal:bg-black/30"
+        pt:header:class="p-0 border-b border-surface-300 dark:border-surface-700 dark:bg-surface-800 shadow"
+        pt:content:class="p-0 bg-surface-100 dark:bg-surface-900"
+        pt:footer:class="py-4 px-6 flex items-center space-x-4 border-t border-surface-300 dark:border-surface-700 bg-white dark:bg-surface-700 shadow-[0_-2px_4px_1px_rgba(0,0,0,0.05)] dark:shadow-[0_-2px_6px_rgba(0,0,0,0.3)]"
+        @update:visible="close"
+    >
+        <template #header>
+            <slot name="header">
+                <div class="px-6 pt-4 flex flex-col space-y-2" :class="{ 'pb-4': tabs?.length < 1 }">
+                    <div class="font-semibold text-black dark:text-gray-200 text-lg z-1">
+                        {{ title }}
+                    </div>
+                    <div v-if="tabs?.length" class="flex flex-wrap -mb-[2px] border-b border-surface-300 dark:border-surface-600 pt-2">
+                        <ul class="flex flex-wrap -mb-px">
+                            <li v-for="(tab, i) in tabs" :key="i" class="mr-2">
+                                <button
+                                    class="inline-flex items-center gap-1 py-2 px-4 border-b-4 rounded-t-lg text-base transition-colors cursor-pointer"
+                                    :disabled="tab?.disabled"
+                                    :class="[
+                                        tab?.disabled
+                                            ? 'text-gray-400 cursor-not-allowed pointer-events-none border-transparent'
+                                            : activeTab === i
+                                                ? 'text-gray-900 dark:text-gray-100 border-surface-600 dark:border-surface-300 font-medium'
+                                                : 'text-gray-500 hover:text-gray-600 hover:border-surface-500 dark:hover:border-surface-400 dark:hover:text-gray-300 dark:text-gray-300 border-transparent'
+                                    ]"
+                                    @click="() => { if (!tab?.disabled) activeTab = i }"
+                                >
+                                    <IconLock v-if="tab?.disabled" size="16" />
+                                    <span>{{ tab.title }}</span>
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </slot>
+        </template>
+        <div class="w-full p-6">
+            <div class="max-w-4xl mx-auto flex flex-col space-y-6 justify-start items-center">
+                <slot v-if="!tabs.length || activeTab === 0" />
+                <template v-else>
+                    <slot :name="`tab-${activeTab}`" />
+                </template>
+            </div>
+        </div>
+        <template #footer>
+            <slot name="footer">
+                <div class="w-full flex flex-col space-y-4">
+                    <slot name="message" />
+                    <Errors :errors="errors" />
+                    <slot name="actions">
+                        <div class="flex items-center space-x-4">
+                            <Button label="Save" :disabled="loading" :loading="loading" @click="emit('submit')" />
+                            <Button text label="Cancel" @click="close" />
+                        </div>
+                    </slot>
+                </div>
+            </slot>
+        </template>
+    </Drawer>
+</template>
+
+<script setup lang="ts">
+import Errors from './Errors.vue';
+import Drawer from './Drawer.vue';
+import Button from './Button.vue';
+import { IconLock } from '@tabler/icons-vue';
+import { ref, watch } from 'vue';
+
+type Tab = { title: string; disabled?: boolean };
+
+const props = defineProps({
+    modelValue: Boolean,
+    title: String,
+    loading: Boolean,
+    width: String,
+    errors: Object as () => Record<string, any>,
+    tabs: {
+        type: Array as () => Tab[],
+        default: () => [],
+    },
+    modelActiveTab: {
+        type: Number,
+        default: 0
+    }
+});
+
+const emit = defineEmits(['update:modelValue', 'submit', 'update:modelActiveTab']);
+const activeTab = ref(props.modelActiveTab);
+
+watch(activeTab, val => emit('update:modelActiveTab', val));
+watch(() => props.modelActiveTab, val => activeTab.value = val);
+
+const close = () => emit('update:modelValue', false);
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -17,6 +17,8 @@ export { default as Badge } from './Badge.vue';
 export { default as Chip } from './Chip.vue';
 export { default as DataTable } from './DataTable.vue';
 export { default as Dialog } from './Dialog.vue';
+export { default as Drawer } from './Drawer.vue';
+export { default as DrawerForm } from './DrawerForm.vue';
 export { default as Divider } from './Divider.vue';
 export { default as ScrollFrame } from './ScrollFrame.vue';
 export { default as Accordion } from './Accordion.vue';


### PR DESCRIPTION
## Summary
- add customizable Drawer wrapper
- introduce DrawerForm for forms with tab support
- document Drawer and DrawerForm usage
- replace custom SecondaryButton with standard Button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a93945d51c83258fdd01d587d22fe5