### PR TITLE
feat(ui): add DialogConfirmation component with passthrough

### DIFF
--- a/ui/src/components/DialogConfirmation.vue
+++ b/ui/src/components/DialogConfirmation.vue
@@ -1,0 +1,110 @@
+<template>
+    <Dialog
+        v-bind="dialogBindProps"
+        :pt="mergedPt.dialog"
+        @update:visible="close"
+    >
+        <div :class="mergedPt.root.class">
+            <slot name="message">
+                <div :class="mergedPt.iconContainer.class">
+                    <i :class="[icon, mergedPt.icon.class]" />
+                </div>
+                <div :class="mergedPt.message.class">
+                    {{ message }}
+                </div>
+            </slot>
+            <div :class="mergedPt.actions.class">
+                <slot name="actions">
+                    <Button
+                        label="Confirm"
+                        raised
+                        :disabled="loading"
+                        :loading="loading"
+                        :pt="mergedPt.confirmButton"
+                        @click="confirm"
+                    />
+                    <Button
+                        text
+                        label="Cancel"
+                        :pt="mergedPt.cancelButton"
+                        @click="close"
+                    />
+                </slot>
+            </div>
+        </div>
+    </Dialog>
+</template>
+
+<script setup lang="ts">
+import Dialog from './Dialog.vue';
+import Button from './Button.vue';
+import { useAttrs, computed } from 'vue';
+import type { DialogProps, DialogPassThroughOptions } from 'primevue/dialog';
+import type { ButtonPassThroughOptions } from 'primevue/button';
+import { ptMerge } from '../utils';
+
+interface DialogConfirmationPassThroughOptions {
+    dialog?: DialogPassThroughOptions;
+    root?: any;
+    iconContainer?: any;
+    icon?: any;
+    message?: any;
+    actions?: any;
+    confirmButton?: ButtonPassThroughOptions;
+    cancelButton?: ButtonPassThroughOptions;
+}
+
+interface Props extends /* @vue-ignore */ Omit<DialogProps, 'visible' | 'header' | 'pt'> {
+    modelValue: boolean;
+    title?: string;
+    icon?: string;
+    message?: string;
+    loading?: boolean;
+    pt?: DialogConfirmationPassThroughOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    title: 'Delete Item',
+    icon: 'pi pi-trash',
+    message: 'Are you sure you want to delete this item?',
+    loading: false,
+});
+const emit = defineEmits(['update:modelValue', 'confirm']);
+const attrs = useAttrs();
+
+const theme = computed<DialogConfirmationPassThroughOptions>(() => ({
+    dialog: {},
+    root: 'relative text-center flex flex-col space-y-6',
+    iconContainer: 'text-gray-400 dark:text-gray-500 mx-auto',
+    icon: 'text-4xl',
+    message: 'text-gray-700 dark:text-gray-200',
+    actions: 'flex justify-center items-center space-x-4 py-2',
+    confirmButton: {
+        root: 'text-white bg-red-600 enabled:hover:bg-red-700 border-red-600 enabled:active:border-red-400 enabled:active:bg-red-600 enabled:hover:border-red-emphasis',
+    },
+    cancelButton: {},
+}));
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+
+const passThroughProps = computed(() => {
+    const { pt, modelValue, title, icon, message, loading, ...rest } = props as any;
+    return rest;
+});
+
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
+const dialogBindProps = computed(() => ({
+    modal: true,
+    dismissableMask: false,
+    closable: false,
+    style: { width: '25rem' },
+    ...bindProps.value,
+    header: props.title,
+    visible: props.modelValue,
+}));
+
+const close = () => emit('update:modelValue', false);
+const confirm = () => emit('confirm');
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -17,6 +17,7 @@ export { default as Badge } from './Badge.vue';
 export { default as Chip } from './Chip.vue';
 export { default as DataTable } from './DataTable.vue';
 export { default as Dialog } from './Dialog.vue';
+export { default as DialogConfirmation } from './DialogConfirmation.vue';
 export { default as Divider } from './Divider.vue';
 export { default as ScrollFrame } from './ScrollFrame.vue';
 export { default as Accordion } from './Accordion.vue';


### PR DESCRIPTION
## Summary
- add DialogConfirmation component with default styling and passthrough support
- expose DialogConfirmation from components index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a93a9e4e008325b87281f03e5a6ec3