### PR TITLE
docs(ui): add table guide and expand editor toolbar docs

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,7 +2,63 @@
 
 Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
 
-## Overriding Themes with Passthrough
+## Table of Contents
+- [Application](#application)
+- [Override Themes with Passthrough](#override-themes-with-passthrough)
+- [Components](#components)
+  - [Actions](#actions)
+    - [Button](#button)
+    - [ButtonGroup](#buttongroup)
+  - [Form Elements](#form-elements)
+    - [InputText](#inputtext)
+    - [InputNumber](#inputnumber)
+    - [InputMask](#inputmask)
+    - [InputGroup](#inputgroup)
+    - [InputOtp](#inputotp)
+    - [DatePicker](#datepicker)
+    - [Select](#select)
+    - [AutoComplete](#autocomplete)
+    - [MultiSelect](#multiselect)
+    - [Textarea](#textarea)
+    - [Checkbox](#checkbox)
+    - [RadioButton](#radiobutton)
+    - [LabelField](#labelfield)
+    - [LabelChoice](#labelchoice)
+    - [ToggleButton](#togglebutton)
+    - [ToggleSwitch](#toggleswitch)
+    - [Password](#password)
+    - [Slider](#slider)
+    - [Editor](#editor)
+  - [Layout](#layout)
+    - [ScrollFrame](#scrollframe)
+    - [Accordion](#accordion)
+    - [Card](#card)
+    - [Divider](#divider)
+    - [Dialog](#dialog)
+    - [Drawer](#drawer)
+    - [DrawerForm](#drawerform)
+    - [Popover](#popover)
+    - [Tabs](#tabs)
+  - [Data Display](#data-display)
+    - [DataTable](#datatable)
+    - [Avatar](#avatar)
+    - [AvatarGroup](#avatargroup)
+    - [Chip](#chip)
+    - [Badge](#badge)
+    - [TooltipIcon](#tooltipicon)
+    - [TooltipInfo](#tooltipinfo)
+  - [Navigation](#navigation)
+    - [ButtonMenu](#buttonmenu)
+    - [Menu](#menu)
+    - [Paginator](#paginator)
+    - [Pagination](#pagination)
+  - [Feedback](#feedback)
+    - [Alert](#alert)
+    - [Errors](#errors)
+    - [Toast](#toast)
+    - [ProgressBar](#progressbar)
+
+## Override Themes with Passthrough
 
 PrimeVue components support a [passthrough (pt) API](https://primevue.org/passthrough/) that lets you customize internal elements and classes. Atlas forwards this API so you can tweak component styles or structure when needed.
 
@@ -18,60 +74,11 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
 />
 ```
 
-## Components
+## Application
 
-### Table of Contents
-- [Actions](#actions)
-  - [Button](#button)
-  - [ButtonGroup](#buttongroup)
-- [Form Elements](#form-elements)
-  - [InputText](#inputtext)
-  - [InputNumber](#inputnumber)
-  - [InputMask](#inputmask)
-  - [InputGroup](#inputgroup)
-  - [InputOtp](#inputotp)
-  - [DatePicker](#datepicker)
-  - [Select](#select)
-  - [AutoComplete](#autocomplete)
-  - [MultiSelect](#multiselect)
-  - [Textarea](#textarea)
-  - [Checkbox](#checkbox)
-  - [RadioButton](#radiobutton)
-  - [LabelField](#labelfield)
-  - [LabelChoice](#labelchoice)
-  - [ToggleButton](#togglebutton)
-  - [ToggleSwitch](#toggleswitch)
-  - [Password](#password)
-  - [Slider](#slider)
-  - [Editor](#editor)
-- [Layout](#layout)
-  - [ScrollFrame](#scrollframe)
-  - [Accordion](#accordion)
-  - [Card](#card)
-  - [Divider](#divider)
-  - [Dialog](#dialog)
-  - [Drawer](#drawer)
-  - [DrawerForm](#drawerform)
-  - [Popover](#popover)
-  - [Tabs](#tabs)
-- [Data Display](#data-display)
-  - [DataTable](#datatable)
-  - [Avatar](#avatar)
-  - [AvatarGroup](#avatargroup)
-  - [Chip](#chip)
-  - [Badge](#badge)
-  - [TooltipIcon](#tooltipicon)
-  - [TooltipInfo](#tooltipinfo)
-- [Navigation](#navigation)
-  - [ButtonMenu](#buttonmenu)
-  - [Menu](#menu)
-  - [Paginator](#paginator)
-  - [Pagination](#pagination)
-- [Feedback](#feedback)
-  - [Alert](#alert)
-  - [Errors](#errors)
-  - [Toast](#toast)
-  - [ProgressBar](#progressbar)
+See the [Application UI guide](ui/application.md) for the app's page structure and layout.
+
+## Components
 
 ### Actions
 
@@ -368,6 +375,10 @@ import { Slider } from '@atlas/ui';
 See the [PrimeVue Slider API](https://primevue.org/slider/#api).
 
 #### Editor
+
+See the [Editor guide](ui/editor.md) for dependencies and usage.
+
+
 ```ts
 import { Editor } from '@atlas/ui';
 ```
@@ -576,6 +587,7 @@ import Column from 'primevue/column';
 ##### API
 
 Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api).
+See the [Table guide](ui/table.md) for column definitions, pagination, and CSV export.
 
 #### Avatar
 ```ts

--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -1,0 +1,29 @@
+# Application UI
+
+Documentation for the Atlas application's overall structure and layout.
+
+## Table of Contents
+- [Page Structure](#page-structure)
+  - [Header](#header)
+  - [Sidebar](#sidebar)
+  - [Main Content](#main-content)
+  - [Footer](#footer)
+- [Navigation](#navigation)
+
+## Page Structure
+
+### Header
+Provides global navigation and user controls.
+
+### Sidebar
+Hosts primary section links and contextual actions.
+
+### Main Content
+Displays the active page's content and interactions.
+
+### Footer
+Contains legal links and auxiliary information.
+
+## Navigation
+Routing between pages uses Vue Router with lazy-loaded routes for performance.
+

--- a/docs/ui/editor.md
+++ b/docs/ui/editor.md
@@ -1,0 +1,44 @@
+# Editor
+
+The Atlas rich text editor builds on [TipTap](https://tiptap.dev/) to provide an extensible editing experience.
+
+## Dependencies
+- `@tiptap/vue-3`
+- `@tiptap/starter-kit`
+
+## Features
+- Formatting toolbar with bold, italic, strikethrough, bullet and ordered lists, link, and clear formatting options
+- Headings and lists
+- Code blocks and blockquotes
+- Link support
+- Keyboard shortcuts for common actions
+
+## Toolbar
+The toolbar exposes the following tools:
+
+- **bold** – toggle bold text
+- **italic** – toggle italic text
+- **strike** – toggle strikethrough
+- **bullet** – create a bulleted list
+- **ordered** – create a numbered list
+- **link** – prompt for a URL and apply it to the selection
+- **clear** – remove formatting from the selection
+
+Customize the toolbar by passing a `toolbarOptions` array. The default order is `['bold','italic','strike','bullet','ordered','link','clear']`.
+
+```vue
+<Editor v-model="content" :toolbar-options="['bold','italic','bullet']" />
+```
+
+Set `toolbar` to `false` to hide it completely.
+
+## Usage
+```ts
+import { Editor } from '@atlas/ui';
+```
+
+```vue
+<Editor v-model="content" :toolbar="true" />
+```
+Bind `v-model` to your data to read and write HTML content.
+

--- a/docs/ui/table.md
+++ b/docs/ui/table.md
@@ -1,0 +1,42 @@
+# Table
+
+Atlas DataTable component extends PrimeVue's DataTable with Atlas styling and utilities.
+
+## Table of Contents
+- [Basic Usage](#basic-usage)
+- [Columns](#columns)
+- [Pagination and Sorting](#pagination-and-sorting)
+- [CSV Export](#csv-export)
+
+## Basic Usage
+```ts
+import { DataTable } from '@atlas/ui';
+import Column from 'primevue/column';
+```
+
+```vue
+<DataTable :value="rows">
+  <Column field="name" header="Name" />
+  <Column field="email" header="Email" />
+</DataTable>
+```
+
+## Columns
+Define columns using PrimeVue's `<Column>` components. Slot templates may be used for custom cell content.
+
+## Pagination and Sorting
+Enable pagination and sorting via PrimeVue props such as `paginator`, `rows`, `sortField`, and `sortOrder`.
+
+```vue
+<DataTable :value="rows" paginator :rows="10" sortField="name" :sortOrder="1" />
+```
+
+## CSV Export
+Call the `exportCSV` method on the component reference to download data.
+
+```vue
+<DataTable ref="dt" :value="rows" />
+<Button @click="dt.exportCSV()" label="Export" />
+```
+
+Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api) for all available options.


### PR DESCRIPTION
## Summary
- reorganize main UI guide with table of contents and link to table doc
- document table component usage, columns, pagination, and CSV export
- expand editor docs with toolbar tool descriptions and customization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a93c098d008325aaccc83b86e18e40