### PR TITLE
feat(playground): switch to side nav

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -9,17 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tabler/icons-vue": "^3.34.1",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.7",
     "vue": "^3.5.18",
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.1",
+    "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
+    "@vitejs/plugin-vue": "^6.0.1",
     "tailwindcss": "^4.1.4",
     "tailwindcss-primeui": "^0.6.1",
-    "@tailwindcss/typography": "^0.5.16",
     "vite": "^7.1.2"
   }
 }

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -3,15 +3,27 @@ import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@ui/components/App/Index.vue';
 import RouterLink from './components/RouterLink.vue';
+import { IconHome, IconHandClick, IconForms, IconTable } from '@tabler/icons-vue';
 
 const route = useRoute();
 
-const topBarItems = [
+const sideBarItems = computed(() => [
+  {
+    children: [
+      { label: 'Home', href: '/', icon: IconHome, activeIcon: IconHome },
+      { label: 'Buttons', href: '/buttons', icon: IconHandClick, activeIcon: IconHandClick },
+      { label: 'Form', href: '/form', icon: IconForms, activeIcon: IconForms },
+      { label: 'Data', href: '/data', icon: IconTable, activeIcon: IconTable },
+    ],
+  },
+]);
+
+const pageNavItems = computed(() => [
   { label: 'Home', href: '/' },
   { label: 'Buttons', href: '/buttons' },
-  { label: 'Form', href: '/form' },
-  { label: 'Data', href: '/data' },
-];
+  { label: 'Form Inputs', href: '/form' },
+  { label: 'Data Table', href: '/data' },
+]);
 
 const pageTitle = computed(() => route.meta.title || '');
 </script>
@@ -20,9 +32,10 @@ const pageTitle = computed(() => route.meta.title || '');
   <UiApp
     :pageUrl="route.path"
     :pageTitle="pageTitle"
-    :topBarItems="topBarItems"
+    :sideBarItems="sideBarItems"
+    :pageNavItems="pageNavItems"
     :linkComponent="RouterLink"
-    :isSideNav="false"
+    :isSideNav="true"
   >
     <RouterView />
   </UiApp>


### PR DESCRIPTION
## Summary
- replace top bar with icon-based side nav in playground
- add page-level side navigation for component demos
- include Tabler icon dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a93f79218c83258624ed04ee6aa395