### PR TITLE
fix: ensure playground nav highlights active page

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -30,7 +30,7 @@ const pageTitle = computed(() => route.meta.title || '');
 
 <template>
   <UiApp
-    :pageUrl="route.path"
+    :pageUrl="route.fullPath"
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
     :pageNavItems="pageNavItems"

--- a/playground/src/inertia.js
+++ b/playground/src/inertia.js
@@ -1,0 +1,15 @@
+import { reactive, computed } from 'vue';
+import { useRoute } from 'vue-router';
+
+// Minimal stub of Inertia's usePage for the playground environment.
+// Returns a reactive page object whose url updates with the current route.
+export function usePage() {
+  const route = useRoute();
+  return reactive({
+    url: computed(() => route.fullPath),
+    component: '',
+    props: {},
+  });
+}
+
+export default { usePage };

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -8,7 +8,8 @@ export default defineConfig({
   plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
-      '@ui': path.resolve(__dirname, '../ui/src')
+      '@ui': path.resolve(__dirname, '../ui/src'),
+      '@inertiajs/vue3': path.resolve(__dirname, './src/inertia.js')
     }
   },
   server: {


### PR DESCRIPTION
## Summary
- stub Inertia `usePage` in playground to provide current route URL
- alias Inertia library to stub and pass `route.fullPath` to `UiApp`

## Testing
- `npm test` (ui)
- `composer test` (laravel) *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9425610288325aa1d4eeed1d7f2d6