### PR TITLE
fix: ensure tailwind styles load in playground

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,4 +1,5 @@
-@source "../ui/src/**/*.{vue,js,ts,jsx,tsx}";
+@source "./**/*.{html,vue,js,ts,jsx,tsx}";
+@source "../../ui/src/**/*.{vue,js,ts,jsx,tsx}";
 
 @import "./base.css";
 

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,4 +1,4 @@
-@source "../../ui/src/**/*.{vue,js,ts,jsx,tsx}";
+@source "../ui/src/**/*.{vue,js,ts,jsx,tsx}";
 
 @import "./base.css";
 

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,10 +1,10 @@
+@source "../../ui/src/**/*.{vue,js,ts,jsx,tsx}";
+
 @import "./base.css";
 
 @import "tailwindcss";
 
 @import "tailwindcss-primeui";
-
-@source "../../ui/src/**/*.{vue,js,ts,jsx,tsx}";
 
 @plugin "@tailwindcss/typography";
 

--- a/playground/tailwind.config.js
+++ b/playground/tailwind.config.js
@@ -5,4 +5,9 @@ export default {
       './src/**/*.{vue,js,ts,jsx,tsx}',
       '../ui/src/**/*.{vue,js,ts,jsx,tsx}',
   ],
+  safelist: [
+    {
+      pattern: /(bg|text|border|ring|shadow|p|m)-(.*)/,
+    },
+  ],
 }

--- a/playground/tailwind.config.js
+++ b/playground/tailwind.config.js
@@ -3,6 +3,6 @@ export default {
   content: [
       './index.html',
       './src/**/*.{vue,js,ts,jsx,tsx}',
-      '../src/**/*.{vue,js,ts,jsx,tsx}',
+      '../ui/src/**/*.{vue,js,ts,jsx,tsx}',
   ],
 }


### PR DESCRIPTION
## Summary
- include ui component paths in playground Tailwind config
- prioritize Tailwind source directive in playground styles

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit: not found)*
- `npm run build` *(fails: Rollup failed to resolve import "vue-router" from "/workspace/atlas/playground/src/App.vue")*

------
https://chatgpt.com/codex/tasks/task_b_68a9445790ac8325bbf5b96b3d896507