### PR TITLE
docs: expand application UI component usage

### DIFF
--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -3,27 +3,154 @@
 Documentation for the Atlas application's overall structure and layout.
 
 ## Table of Contents
-- [Page Structure](#page-structure)
-  - [Header](#header)
-  - [Sidebar](#sidebar)
-  - [Main Content](#main-content)
-  - [Footer](#footer)
 - [Navigation](#navigation)
-
-## Page Structure
-
-### Header
-Provides global navigation and user controls.
-
-### Sidebar
-Hosts primary section links and contextual actions.
-
-### Main Content
-Displays the active page's content and interactions.
-
-### Footer
-Contains legal links and auxiliary information.
+  - [NavTopbar](#navtopbar)
+  - [NavSidebar](#navsidebar)
+  - [PageSideNav](#pagesidenav)
+- [Layout](#layout)
+  - [PageHeader](#pageheader)
+  - [PageContent](#pagecontent)
+  - [PageFooter](#pagefooter)
 
 ## Navigation
-Routing between pages uses Vue Router with lazy-loaded routes for performance.
+Components that allow users to navigate across or within pages.
+
+### NavTopbar
+Global top navigation bar.
+
+```ts
+import { NavTopbar } from '@atlas/ui';
+```
+
+```vue
+<NavTopbar :items="navItems">
+  <template #actions>
+    <!-- optional action buttons -->
+  </template>
+</NavTopbar>
+```
+
+**Props**
+- `items: NavItem[]` – navigation links, supports nested `children`.
+- `linkComponent: string | object` – component used for links. Default `'a'`.
+- `homeUrl: string` – root link. Default `'/'`.
+- `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
+
+**Events**
+- None
+
+### NavSidebar
+Vertical navigation sidebar.
+
+```ts
+import { NavSidebar } from '@atlas/ui';
+```
+
+```vue
+<NavSidebar :items="navItems">
+  <template #actions>
+    <!-- footer actions -->
+  </template>
+</NavSidebar>
+```
+
+**Props**
+- `items: NavItem[]` – sections and links displayed in the sidebar.
+- `homeUrl: string` – root link. Default `'/'`.
+- `linkComponent: string | object` – component used for links. Default `'a'`.
+
+**Events**
+- None
+
+### PageSideNav
+Secondary navigation within a page.
+
+```ts
+import { PageSideNav } from '@atlas/ui';
+```
+
+```vue
+<PageSideNav :items="sideItems" />
+```
+
+**Props**
+- `items: NavItem[]` – navigation links. Default `[]`.
+- `linkComponent: string | object` – component used for links. Default `'a'`.
+
+**Events**
+- None
+
+## Layout
+Structural components that organize page content and actions.
+
+### PageHeader
+Page-level header with optional breadcrumbs and tabs.
+
+```ts
+import { PageHeader } from '@atlas/ui';
+```
+
+```vue
+<PageHeader
+  :breadcrumbs="[{ href: '/', title: 'Home' }]"
+  title="Dashboard"
+/>
+```
+
+**Props**
+- `breadcrumbs: Breadcrumb[]` – items for the breadcrumb trail. Default `[]`.
+- `tabs: Tab[]` – optional tab navigation. Default `[]`.
+- `title: string` – page title text. Default `''`.
+- `linkComponent: string | object` – component used for links. Default `'a'`.
+- `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
+- `hideTitle: boolean` – hide the title section. Default `false`.
+
+**Events**
+- None
+
+### PageContent
+Scrollable main content area.
+
+```ts
+import { PageContent } from '@atlas/ui';
+```
+
+```vue
+<PageContent :offset="64">
+  <!-- page body -->
+</PageContent>
+```
+
+**Props**
+- `offset: number | null` – top offset for fixed headers. Default `null`.
+- `footerHeight: number` – height of a sticky footer to offset. Default `0`.
+- `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
+- `containerClass: string` – additional container classes. Default `'mx-auto p-4'`.
+
+**Events**
+- None
+
+### PageFooter
+Sticky footer with optional action slot.
+
+```ts
+import { PageFooter } from '@atlas/ui';
+```
+
+```vue
+<PageFooter>
+  <span>&copy; 2024</span>
+  <template #action>
+    <!-- footer action -->
+  </template>
+</PageFooter>
+```
+
+**Props**
+- `leftOffset: number` – offset to account for sidebars. Default `0`.
+- `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
+
+**Events**
+- None
+
 


### PR DESCRIPTION
## Summary
- document NavTopbar, NavSidebar, PageHeader, PageSideNav, PageContent, and PageFooter
- add minimal example usage plus props and events for each
- group navigation and layout components in application UI docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9be8a6cf4832593fa8e1afcaf6a6b