### PR TITLE
Refactor button demos and clean up forms examples

### DIFF
--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -1,24 +1,41 @@
 <script setup>
 import Button from '@ui/components/Button.vue';
+
+const groups = [
+  { title: 'Buttons (regular)', attrs: {} },
+  { title: 'Buttons (regular-outlined)', attrs: { outlined: true } },
+  { title: 'Buttons (regular-text)', attrs: { text: true } },
+  { title: 'Buttons (small)', attrs: { size: 'small' } },
+  { title: 'Buttons (small-outlined)', attrs: { size: 'small', outlined: true } },
+  { title: 'Buttons (small-text)', attrs: { size: 'small', text: true } },
+  { title: 'Buttons (large)', attrs: { size: 'large' } },
+  { title: 'Buttons (large-outlined)', attrs: { size: 'large', outlined: true } },
+  { title: 'Buttons (large-text)', attrs: { size: 'large', text: true } },
+];
+
+const states = [
+  { label: 'Default', attrs: {} },
+  { label: 'Raised', attrs: { raised: true } },
+  { label: 'Rounded', attrs: { rounded: true } },
+  { label: 'Loading', attrs: { loading: true } },
+  { label: 'Disabled', attrs: { disabled: true } },
+];
 </script>
 
 <template>
   <section class="p-4 space-y-4">
     <h2 class="text-xl font-semibold">Buttons</h2>
-    <div class="flex flex-wrap gap-4">
-      <Button>Default</Button>
-      <Button severity="secondary">Secondary</Button>
-      <Button severity="success">Success</Button>
-      <Button severity="info">Info</Button>
-      <Button severity="warning">Warning</Button>
-      <Button severity="danger">Danger</Button>
-      <Button severity="help">Help</Button>
-      <Button outlined>Outlined</Button>
-      <Button text>Text</Button>
-      <Button raised>Raised</Button>
-      <Button rounded>Rounded</Button>
-      <Button :loading="true" label="loading" />
-      <Button disabled>Disabled</Button>
+    <div v-for="group in groups" :key="group.title" class="space-y-2">
+      <h3 class="text-lg font-semibold">{{ group.title }}</h3>
+      <div class="flex flex-wrap gap-4">
+        <Button
+          v-for="state in states"
+          :key="state.label"
+          v-bind="{ ...group.attrs, ...state.attrs }"
+        >
+          {{ state.label }}
+        </Button>
+      </div>
     </div>
   </section>
 </template>

--- a/playground/src/pages/components/Forms.vue
+++ b/playground/src/pages/components/Forms.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, reactive } from 'vue';
-import Column from 'primevue/column';
 import Card from '@ui/components/Card.vue';
 import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
 import Button from '@ui/components/Button.vue';
@@ -24,19 +23,9 @@ import TabList from '@ui/components/TabList.vue';
 import Tab from '@ui/components/Tab.vue';
 import TabPanels from '@ui/components/TabPanels.vue';
 import TabPanel from '@ui/components/TabPanel.vue';
-import DataTable from '@ui/components/DataTable.vue';
 import { useModal } from '@ui/composables';
 
 const { open } = useModal();
-
-const products = ref(
-    Array.from({ length: 100 }, (_, i) => ({
-        code: `P-${String(i + 1).padStart(3, '0')}`,
-        name: `Product ${i + 1}`,
-        category: `Category ${((i % 10) + 1)}`,
-        quantity: Math.floor(Math.random() * 100) + 1,
-    }))
-);
 
 const form = reactive({
     first_name: 'John',
@@ -410,32 +399,7 @@ const search = (event) => {
           </template>
         </Card>
       </div>
-      <div>
-        <Card :pt="{ content: { class: 'p-0' } }">
-          <template #header>
-            <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-              <div>Virtual table</div>
-            </div>
-          </template>
-          <template #content>
-            <div>
-              <DataTable
-                :value="products"
-                tableStyle="min-width: 50rem"
-                paginator
-                :rows="25"
-                scrollable
-                scrollHeight="300px"
-              >
-                <Column field="code" header="Code" sortable></Column>
-                <Column field="name" header="Name" sortable></Column>
-                <Column field="category" header="Category"></Column>
-                <Column field="quantity" header="Quantity"></Column>
-              </DataTable>
-            </div>
-          </template>
-        </Card>
-      </div>
+      
     </div>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- showcase button states by variant and size in playground
- drop table example from forms page

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9c938fa4083258bb8ac538ba1c63f