### PR TITLE
Refactor button demos and move tabs examples

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -23,6 +23,7 @@ const pageNavItems = computed(() => {
       { label: 'Buttons', href: '/components/buttons' },
       { label: 'Forms', href: '/components/forms' },
       { label: 'Tables', href: '/components/tables' },
+      { label: 'Tabs', href: '/components/tabs' },
     ];
   }
 

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Button from '@ui/components/Button.vue';
+import Card from '@ui/components/Card.vue';
 
 const groups = [
   { title: 'Buttons (regular)', attrs: {} },
@@ -25,17 +26,20 @@ const states = [
 <template>
   <section class="p-4 space-y-4">
     <h2 class="text-xl font-semibold">Buttons</h2>
-    <div v-for="group in groups" :key="group.title" class="space-y-2">
-      <h3 class="text-lg font-semibold">{{ group.title }}</h3>
-      <div class="flex flex-wrap gap-4">
-        <Button
-          v-for="state in states"
-          :key="state.label"
-          v-bind="{ ...group.attrs, ...state.attrs }"
-        >
-          {{ state.label }}
-        </Button>
-      </div>
-    </div>
+    <Card v-for="group in groups" :key="group.title">
+      <template #header>
+        <h3 class="text-lg font-semibold">{{ group.title }}</h3>
+      </template>
+      <template #content>
+        <div class="flex flex-wrap gap-4">
+          <Button
+            v-for="state in states"
+            :key="state.label"
+            v-bind="{ ...group.attrs, ...state.attrs }"
+            :label="state.label"
+          />
+        </div>
+      </template>
+    </Card>
   </section>
 </template>

--- a/playground/src/pages/components/Forms.vue
+++ b/playground/src/pages/components/Forms.vue
@@ -14,15 +14,6 @@ import Alert from '@ui/components/Alert.vue';
 import LabelChoice from '@ui/components/LabelChoice.vue';
 import RadioButton from '@ui/components/RadioButton.vue';
 import Checkbox from '@ui/components/Checkbox.vue';
-import Accordion from '@ui/components/Accordion.vue';
-import AccordionPanel from '@ui/components/AccordionPanel.vue';
-import AccordionHeader from '@ui/components/AccordionHeader.vue';
-import AccordionContent from '@ui/components/AccordionContent.vue';
-import Tabs from '@ui/components/Tabs.vue';
-import TabList from '@ui/components/TabList.vue';
-import Tab from '@ui/components/Tab.vue';
-import TabPanels from '@ui/components/TabPanels.vue';
-import TabPanel from '@ui/components/TabPanel.vue';
 import { useModal } from '@ui/composables';
 
 const { open } = useModal();
@@ -326,76 +317,6 @@ const search = (event) => {
               <Button label="Save" @click="open('TEST')" :disabled="true" />
               <Button outlined label="Show blank" @click="open('BLANK_DRAWER')" :disabled="true" />
             </div>
-          </template>
-        </Card>
-      </div>
-      <div class="flex space-x-4">
-        <Card :pt="{ content: { class: 'p-0' } }">
-          <template #header>
-            <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-              <div>Accordion</div>
-            </div>
-          </template>
-          <template #content>
-            <Accordion value="0">
-              <AccordionPanel value="0">
-                <AccordionHeader>Header I</AccordionHeader>
-                <AccordionContent>
-                  <p class="m-0">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                  </p>
-                </AccordionContent>
-              </AccordionPanel>
-              <AccordionPanel value="1">
-                <AccordionHeader>Header II</AccordionHeader>
-                <AccordionContent>
-                  <p class="m-0">
-                    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
-                  </p>
-                </AccordionContent>
-              </AccordionPanel>
-              <AccordionPanel value="2" disabled>
-                <AccordionHeader>Header III (disabled)</AccordionHeader>
-                <AccordionContent>
-                  <p class="m-0">
-                    At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
-                  </p>
-                </AccordionContent>
-              </AccordionPanel>
-            </Accordion>
-          </template>
-        </Card>
-        <Card :pt="{ content: { class: 'p-0' } }">
-          <template #header>
-            <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-              <div>Tabs</div>
-            </div>
-          </template>
-          <template #content>
-            <Tabs value="0">
-              <TabList>
-                <Tab value="0">Header I</Tab>
-                <Tab value="1">Header II</Tab>
-                <Tab value="2">Header III</Tab>
-              </TabList>
-              <TabPanels>
-                <TabPanel value="0">
-                  <p class="m-0">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                  </p>
-                </TabPanel>
-                <TabPanel value="1">
-                  <p class="m-0">
-                    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                  </p>
-                </TabPanel>
-                <TabPanel value="2">
-                  <p class="m-0">
-                    At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                  </p>
-                </TabPanel>
-              </TabPanels>
-            </Tabs>
           </template>
         </Card>
       </div>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -1,0 +1,88 @@
+<script setup>
+import Card from '@ui/components/Card.vue';
+import Accordion from '@ui/components/Accordion.vue';
+import AccordionPanel from '@ui/components/AccordionPanel.vue';
+import AccordionHeader from '@ui/components/AccordionHeader.vue';
+import AccordionContent from '@ui/components/AccordionContent.vue';
+import Tabs from '@ui/components/Tabs.vue';
+import TabList from '@ui/components/TabList.vue';
+import Tab from '@ui/components/Tab.vue';
+import TabPanels from '@ui/components/TabPanels.vue';
+import TabPanel from '@ui/components/TabPanel.vue';
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <h2 class="text-xl font-semibold">Tabs</h2>
+    <div class="flex space-x-4">
+      <Card :pt="{ root: 'p-0' }">
+        <template #header>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+            <div>Accordion</div>
+          </div>
+        </template>
+        <template #content>
+          <Accordion value="0">
+            <AccordionPanel value="0">
+              <AccordionHeader>Header I</AccordionHeader>
+              <AccordionContent>
+                <p class="m-0">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                </p>
+              </AccordionContent>
+            </AccordionPanel>
+            <AccordionPanel value="1">
+              <AccordionHeader>Header II</AccordionHeader>
+              <AccordionContent>
+                <p class="m-0">
+                  Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+                </p>
+              </AccordionContent>
+            </AccordionPanel>
+            <AccordionPanel value="2" disabled>
+              <AccordionHeader>Header III (disabled)</AccordionHeader>
+              <AccordionContent>
+                <p class="m-0">
+                  At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+                </p>
+              </AccordionContent>
+            </AccordionPanel>
+          </Accordion>
+        </template>
+      </Card>
+      <Card :pt="{ root: 'p-0' }">
+        <template #header>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+            <div>Tabs</div>
+          </div>
+        </template>
+        <template #content>
+          <Tabs value="0">
+            <TabList>
+              <Tab value="0">Header I</Tab>
+              <Tab value="1">Header II</Tab>
+              <Tab value="2">Header III</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel value="0">
+                <p class="m-0">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </TabPanel>
+              <TabPanel value="1">
+                <p class="m-0">
+                  Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </TabPanel>
+              <TabPanel value="2">
+                <p class="m-0">
+                  At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </template>
+      </Card>
+    </div>
+  </section>
+</template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -5,6 +5,7 @@ import ComponentsLayout from './pages/components/Index.vue';
 import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/Forms.vue';
 import Tables from './pages/components/Tables.vue';
+import Tabs from './pages/components/Tabs.vue';
 
 const routes = [
   { path: '/', component: Home, meta: { title: 'Dashboard' } },
@@ -17,6 +18,7 @@ const routes = [
       { path: 'buttons', component: Buttons, meta: { title: 'Buttons' } },
       { path: 'forms', component: Forms, meta: { title: 'Forms' } },
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
+      { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
     ],
   },
 ];

--- a/ui/src/components/App/Page/Header.vue
+++ b/ui/src/components/App/Page/Header.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useSlots } from 'vue';
+import { computed, useSlots, toRefs } from 'vue';
 import { IconLock } from '@tabler/icons-vue';
 import { useScroll } from '../../../composables/useScroll';
 import { hasSlotContent, isPageActive } from '../../../utils';
@@ -129,12 +129,12 @@ const props = withDefaults(defineProps<Props>(), {
     hideTitle: false,
 });
 
-const { breadcrumbs, tabs, title, linkComponent, widthClass, hideTitle } = props;
+const { breadcrumbs, tabs, title, linkComponent, widthClass, hideTitle } = toRefs(props);
 
 const isActiveTab = (tab: Tab) =>
     tab.parent ? isPageActive(tab.parent) : isPageActive(tab.href, undefined, true);
 
 const hasAction = computed(() => hasSlotContent(slots.action));
-const hasTitle = computed(() => hasSlotContent(slots.title) || title);
+const hasTitle = computed(() => hasSlotContent(slots.title) || title.value);
 const { isTop } = useScroll('page');
 </script>


### PR DESCRIPTION
## Summary
- wrap playground button groups in Card and use label props
- fix PageHeader to react to route title changes
- relocate accordion and tabs demos to new Tabs page and update routes

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9ca7b905c832581e241916adbafe3