### PR TITLE
refactor: tidy playground layout and navigation

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -12,7 +12,7 @@ const sideBarItems = computed(() => [
     children: [
       { label: 'Home', href: '/', icon: IconHome, activeIcon: IconHome },
       { label: 'Users', href: '/users', icon: IconUsers, activeIcon: IconUsers },
-      { label: 'Components', href: '/components/buttons', icon: IconSettings, activeIcon: IconSettings },
+      { label: 'Components', href: '/components/buttons', parent: '/components', icon: IconSettings, activeIcon: IconSettings },
     ],
   },
 ]);

--- a/playground/src/pages/Home.vue
+++ b/playground/src/pages/Home.vue
@@ -1,5 +1,3 @@
 <template>
-  <section class="p-4">
-    <h1 class="text-2xl font-bold">Dashboard</h1>
-  </section>
+  <section class="p-4"></section>
 </template>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -1,5 +1,3 @@
 <template>
-  <section class="p-4">
-    <h1 class="text-2xl font-bold">Users table</h1>
-  </section>
+  <section class="p-4"></section>
 </template>

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -25,7 +25,6 @@ const states = [
 
 <template>
   <section class="p-4 space-y-4">
-    <h2 class="text-xl font-semibold">Buttons</h2>
     <Card v-for="group in groups" :key="group.title">
       <template #header>
         <h3 class="text-lg font-semibold">{{ group.title }}</h3>

--- a/playground/src/pages/components/Forms.vue
+++ b/playground/src/pages/components/Forms.vue
@@ -108,7 +108,6 @@ const search = (event) => {
 
 <template>
   <section class="p-4 space-y-4">
-    <h2 class="text-xl font-semibold">Forms</h2>
     <div class="flex flex-col space-y-4">
       <div class="flex space-x-4">
         <Card>

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import DataTable from '@ui/components/DataTable.vue';
 import Column from 'primevue/column';
+import Card from '@ui/components/Card.vue';
 
 const users = ref([
   { name: 'Alice', email: 'alice@example.com', country: 'USA' },
@@ -17,11 +18,14 @@ const users = ref([
 
 <template>
   <section class="p-4 space-y-4">
-    <h2 class="text-xl font-semibold">Tables</h2>
-    <DataTable :value="users" paginator :rows="5">
-      <Column field="name" header="Name" />
-      <Column field="email" header="Email" />
-      <Column field="country" header="Country" />
-    </DataTable>
+    <Card :pt="{ content: 'p-0' }">
+      <template #content>
+        <DataTable :value="users" paginator :rows="5">
+          <Column field="name" header="Name" />
+          <Column field="email" header="Email" />
+          <Column field="country" header="Country" />
+        </DataTable>
+      </template>
+    </Card>
   </section>
 </template>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -13,16 +13,14 @@ import TabPanel from '@ui/components/TabPanel.vue';
 
 <template>
   <section class="p-4 space-y-4">
-    <h2 class="text-xl font-semibold">Tabs</h2>
-    <div class="flex space-x-4">
-      <Card :pt="{ root: 'p-0' }">
-        <template #header>
-          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-            <div>Accordion</div>
-          </div>
-        </template>
-        <template #content>
-          <Accordion value="0">
+    <Card>
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>Accordion</div>
+        </div>
+      </template>
+      <template #content>
+        <Accordion value="0">
             <AccordionPanel value="0">
               <AccordionHeader>Header I</AccordionHeader>
               <AccordionContent>
@@ -50,14 +48,14 @@ import TabPanel from '@ui/components/TabPanel.vue';
           </Accordion>
         </template>
       </Card>
-      <Card :pt="{ root: 'p-0' }">
-        <template #header>
-          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-            <div>Tabs</div>
-          </div>
-        </template>
-        <template #content>
-          <Tabs value="0">
+    <Card>
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>Tabs</div>
+        </div>
+      </template>
+      <template #content>
+        <Tabs value="0">
             <TabList>
               <Tab value="0">Header I</Tab>
               <Tab value="1">Header II</Tab>
@@ -83,6 +81,5 @@ import TabPanel from '@ui/components/TabPanel.vue';
           </Tabs>
         </template>
       </Card>
-    </div>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- remove redundant page headings from playground pages
- wrap demo table in card without padding
- stack tabs and accordion demos vertically and fix Components side-nav highlighting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9cbc006e88325a281015ac82d62d5