### PR TITLE
feat: add editor showcase pages

### DIFF
--- a/playground/src/pages/components/editor/Index.vue
+++ b/playground/src/pages/components/editor/Index.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import Card from '@ui/components/Card.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+import RouterLink from '../../../components/RouterLink.vue';
+
+const route = useRoute();
+const editContent = ref('');
+
+const pageTabs = [
+  { title: 'Overview', href: '/components/editor' },
+  { title: 'Variants', href: '/components/editor/variant' },
+  { title: 'Text', href: '/components/editor/text' },
+];
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <div class="flex space-x-4 border-b pb-2 mb-4">
+      <RouterLink
+        v-for="tab in pageTabs"
+        :key="tab.href"
+        :href="tab.href"
+        class="px-2 py-1 text-sm"
+        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
+      >
+        {{ tab.title }}
+      </RouterLink>
+    </div>
+    <Card>
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>Editor</div>
+        </div>
+      </template>
+      <template #content>
+        <div class="border border-surface-300 dark:border-surface-700 rounded-md">
+          <Editor v-model="editContent" />
+        </div>
+      </template>
+    </Card>
+    <Card>
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>View content</div>
+        </div>
+      </template>
+      <template #content>
+        <Content :content="editContent" />
+      </template>
+    </Card>
+    <Card>
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>View content (as HTML)</div>
+        </div>
+      </template>
+      <template #content>
+        <Textarea v-model="editContent" readonly fluid rows="10" />
+      </template>
+    </Card>
+  </section>
+</template>

--- a/playground/src/pages/components/editor/Text.vue
+++ b/playground/src/pages/components/editor/Text.vue
@@ -1,0 +1,49 @@
+<script setup>
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import Card from '@ui/components/Card.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+import RouterLink from '../../../components/RouterLink.vue';
+
+const route = useRoute();
+const editContent = ref('');
+
+const pageTabs = [
+  { title: 'Overview', href: '/components/editor' },
+  { title: 'Variants', href: '/components/editor/variant' },
+  { title: 'Text', href: '/components/editor/text' },
+];
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <div class="flex space-x-4 border-b pb-2 mb-4">
+      <RouterLink
+        v-for="tab in pageTabs"
+        :key="tab.href"
+        :href="tab.href"
+        class="px-2 py-1 text-sm"
+        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
+      >
+        {{ tab.title }}
+      </RouterLink>
+    </div>
+    <Card pt:content:class="p-0">
+      <template #content>
+        <Editor v-model="editContent" textOnly placeholder="Start typing for text output..." />
+      </template>
+    </Card>
+    <Card v-if="editContent">
+      <template #content>
+        <Content :content="editContent" />
+      </template>
+    </Card>
+    <Card v-if="editContent">
+      <template #content>
+        <Textarea v-model="editContent" readonly fluid rows="10" />
+      </template>
+    </Card>
+  </section>
+</template>

--- a/playground/src/pages/components/editor/Variant.vue
+++ b/playground/src/pages/components/editor/Variant.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import Card from '@ui/components/Card.vue';
+import Button from '@ui/components/Button.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+import RouterLink from '../../../components/RouterLink.vue';
+
+const route = useRoute();
+const editContent = ref('');
+
+const pageTabs = [
+  { title: 'Overview', href: '/components/editor' },
+  { title: 'Variants', href: '/components/editor/variant' },
+  { title: 'Text', href: '/components/editor/text' },
+];
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <div class="flex space-x-4 border-b pb-2 mb-4">
+      <RouterLink
+        v-for="tab in pageTabs"
+        :key="tab.href"
+        :href="tab.href"
+        class="px-2 py-1 text-sm"
+        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
+      >
+        {{ tab.title }}
+      </RouterLink>
+    </div>
+    <Card pt:content:class="p-0">
+      <template #content>
+        <Editor v-model="editContent" placeholder="Start typing..." />
+      </template>
+    </Card>
+    <Card pt:content:class="p-0">
+      <template #content>
+        <div class="bg-yellow-100/60 w-full flex flex-col">
+          <div>
+            <Editor v-model="editContent" toolbarClass="" />
+          </div>
+          <div class="flex items-center space-x-2 px-4 pb-4">
+            <Button label="Save" raised size="small" />
+            <Button text label="Cancel" size="small" @click="editContent = ''" />
+          </div>
+        </div>
+      </template>
+    </Card>
+    <Card pt:content:class="p-0">
+      <template #content>
+        <Editor v-model="editContent" :toolbarOptions="['bold', 'italic', 'strike']" placeholder="Limited options" />
+      </template>
+    </Card>
+    <Card pt:content:class="p-0">
+      <template #content>
+        <Editor v-model="editContent" :toolbar="false" placeholder="No toolbar editor" />
+      </template>
+    </Card>
+    <Card v-if="editContent">
+      <template #content>
+        <Content :content="editContent" />
+      </template>
+    </Card>
+    <Card v-if="editContent">
+      <template #content>
+        <Textarea v-model="editContent" readonly fluid rows="10" />
+      </template>
+    </Card>
+  </section>
+</template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -6,6 +6,9 @@ import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/Forms.vue';
 import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
+import Editor from './pages/components/editor/Index.vue';
+import EditorVariant from './pages/components/editor/Variant.vue';
+import EditorText from './pages/components/editor/Text.vue';
 
 const routes = [
   { path: '/', component: Home, meta: { title: 'Dashboard' } },
@@ -19,6 +22,9 @@ const routes = [
       { path: 'forms', component: Forms, meta: { title: 'Forms' } },
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
+      { path: 'editor', component: Editor, meta: { title: 'Editor' } },
+      { path: 'editor/variant', component: EditorVariant, meta: { title: 'Editor Variants' } },
+      { path: 'editor/text', component: EditorText, meta: { title: 'Editor Text' } },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- add editor overview page with live content and HTML views
- demonstrate editor variants and text-only mode
- register editor routes in playground router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9cd1be6a4832594ce610bdae06bfb