### PR TITLE
Add overlays demo and adjust component cards

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -24,6 +24,7 @@ const pageNavItems = computed(() => {
       { label: 'Forms', href: '/components/forms' },
       { label: 'Tables', href: '/components/tables' },
       { label: 'Tabs', href: '/components/tabs' },
+      { label: 'Overlays', href: '/components/overlays' },
     ];
   }
 

--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { ref } from 'vue';
+import Card from '@ui/components/Card.vue';
+import Button from '@ui/components/Button.vue';
+import Drawer from '@ui/components/Drawer.vue';
+import Dialog from '@ui/components/Dialog.vue';
+
+const drawerVisible = ref(false);
+const dialogVisible = ref(false);
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <Card :pt="{ root: 'p-0' }">
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
+          Drawer
+        </div>
+      </template>
+      <div class="p-4">
+        <Button label="Open Drawer" @click="drawerVisible = true" />
+      </div>
+      <Drawer v-model:visible="drawerVisible" header="Drawer">
+        <p class="m-0 p-4">Drawer Content</p>
+      </Drawer>
+    </Card>
+
+    <Card :pt="{ root: 'p-0' }">
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
+          Modal
+        </div>
+      </template>
+      <div class="p-4">
+        <Button label="Open Modal" @click="dialogVisible = true" />
+      </div>
+      <Dialog v-model:visible="dialogVisible" header="Modal">
+        <p class="m-0 p-4">Modal Content</p>
+        <template #footer>
+          <Button label="Close" @click="dialogVisible = false" />
+        </template>
+      </Dialog>
+    </Card>
+  </section>
+</template>

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -18,14 +18,12 @@ const users = ref([
 
 <template>
   <section class="p-4 space-y-4">
-    <Card :pt="{ content: 'p-0' }">
-      <template #content>
-        <DataTable :value="users" paginator :rows="5">
-          <Column field="name" header="Name" />
-          <Column field="email" header="Email" />
-          <Column field="country" header="Country" />
-        </DataTable>
-      </template>
+    <Card :pt="{ root: 'p-0' }">
+      <DataTable :value="users" paginator :rows="5">
+        <Column field="name" header="Name" />
+        <Column field="email" header="Email" />
+        <Column field="country" header="Country" />
+      </DataTable>
     </Card>
   </section>
 </template>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -13,13 +13,12 @@ import TabPanel from '@ui/components/TabPanel.vue';
 
 <template>
   <section class="p-4 space-y-4">
-    <Card>
+    <Card :pt="{ root: 'p-0' }">
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
           <div>Accordion</div>
         </div>
       </template>
-      <template #content>
         <Accordion value="0">
             <AccordionPanel value="0">
               <AccordionHeader>Header I</AccordionHeader>
@@ -46,16 +45,14 @@ import TabPanel from '@ui/components/TabPanel.vue';
               </AccordionContent>
             </AccordionPanel>
           </Accordion>
+        </Card>
+      <Card :pt="{ root: 'p-0' }">
+        <template #header>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+            <div>Tabs</div>
+          </div>
         </template>
-      </Card>
-    <Card>
-      <template #header>
-        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-          <div>Tabs</div>
-        </div>
-      </template>
-      <template #content>
-        <Tabs value="0">
+          <Tabs value="0">
             <TabList>
               <Tab value="0">Header I</Tab>
               <Tab value="1">Header II</Tab>
@@ -78,8 +75,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
                 </p>
               </TabPanel>
             </TabPanels>
-          </Tabs>
-        </template>
-      </Card>
-  </section>
-</template>
+            </Tabs>
+        </Card>
+    </section>
+  </template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -6,6 +6,7 @@ import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/Forms.vue';
 import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
+import Overlays from './pages/components/Overlays.vue';
 import Editor from './pages/components/editor/Index.vue';
 import EditorVariant from './pages/components/editor/Variant.vue';
 import EditorText from './pages/components/editor/Text.vue';
@@ -22,6 +23,7 @@ const routes = [
       { path: 'forms', component: Forms, meta: { title: 'Forms' } },
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
+      { path: 'overlays', component: Overlays, meta: { title: 'Overlays' } },
       { path: 'editor', component: Editor, meta: { title: 'Editor' } },
       { path: 'editor/variant', component: EditorVariant, meta: { title: 'Editor Variants' } },
       { path: 'editor/text', component: EditorText, meta: { title: 'Editor Text' } },


### PR DESCRIPTION
## Summary
- wrap tables and tabs in cards without padding
- add overlays demo page with drawer and modal examples

## Testing
- `cd ui && npm test`
- `cd playground && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a9ce1cbee883259d4cd71fe37d1722