### PR TITLE
feat(playground): add editor to page navigation

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -17,20 +17,33 @@ const sideBarItems = computed(() => [
   },
 ]);
 
-const pageNavItems = computed(() => {
-  if (route.path.startsWith('/components')) {
-    return [
-      { label: 'Buttons', href: '/components/buttons' },
-      { label: 'Forms', href: '/components/forms' },
-      { label: 'Tables', href: '/components/tables' },
-      { label: 'Tabs', href: '/components/tabs' },
-    ];
-  }
+  const pageNavItems = computed(() => {
+    if (route.path.startsWith('/components')) {
+      return [
+        { label: 'Buttons', href: '/components/buttons' },
+        { label: 'Forms', href: '/components/forms' },
+        { label: 'Tables', href: '/components/tables' },
+        { label: 'Tabs', href: '/components/tabs' },
+        { label: 'Editor', href: '/components/editor', parent: '/components/editor' },
+      ];
+    }
 
-  return [];
-});
+    return [];
+  });
 
-const pageTitle = computed(() => route.meta.title || '');
+  const pageTabs = computed(() => {
+    if (route.path.startsWith('/components/editor')) {
+      return [
+        { title: 'Overview', href: '/components/editor' },
+        { title: 'Variants', href: '/components/editor/variant' },
+        { title: 'Text', href: '/components/editor/text' },
+      ];
+    }
+
+    return [];
+  });
+
+  const pageTitle = computed(() => route.meta.title || '');
 </script>
 
 <template>
@@ -39,6 +52,7 @@ const pageTitle = computed(() => route.meta.title || '');
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
     :pageNavItems="pageNavItems"
+    :pageTabs="pageTabs"
     :linkComponent="RouterLink"
     :isSideNav="true"
   >

--- a/playground/src/pages/components/editor/Index.vue
+++ b/playground/src/pages/components/editor/Index.vue
@@ -1,35 +1,15 @@
 <script setup>
 import { ref } from 'vue';
-import { useRoute } from 'vue-router';
 import Card from '@ui/components/Card.vue';
 import Editor from '@ui/components/Editor/Index.vue';
 import Content from '@ui/components/Editor/EditorContent.vue';
 import Textarea from '@ui/components/Textarea.vue';
-import RouterLink from '../../../components/RouterLink.vue';
 
-const route = useRoute();
 const editContent = ref('');
-
-const pageTabs = [
-  { title: 'Overview', href: '/components/editor' },
-  { title: 'Variants', href: '/components/editor/variant' },
-  { title: 'Text', href: '/components/editor/text' },
-];
 </script>
 
 <template>
   <section class="p-4 space-y-4">
-    <div class="flex space-x-4 border-b pb-2 mb-4">
-      <RouterLink
-        v-for="tab in pageTabs"
-        :key="tab.href"
-        :href="tab.href"
-        class="px-2 py-1 text-sm"
-        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
-      >
-        {{ tab.title }}
-      </RouterLink>
-    </div>
     <Card>
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">

--- a/playground/src/pages/components/editor/Text.vue
+++ b/playground/src/pages/components/editor/Text.vue
@@ -1,35 +1,15 @@
 <script setup>
 import { ref } from 'vue';
-import { useRoute } from 'vue-router';
 import Card from '@ui/components/Card.vue';
 import Editor from '@ui/components/Editor/Index.vue';
 import Content from '@ui/components/Editor/EditorContent.vue';
 import Textarea from '@ui/components/Textarea.vue';
-import RouterLink from '../../../components/RouterLink.vue';
 
-const route = useRoute();
 const editContent = ref('');
-
-const pageTabs = [
-  { title: 'Overview', href: '/components/editor' },
-  { title: 'Variants', href: '/components/editor/variant' },
-  { title: 'Text', href: '/components/editor/text' },
-];
 </script>
 
 <template>
   <section class="p-4 space-y-4">
-    <div class="flex space-x-4 border-b pb-2 mb-4">
-      <RouterLink
-        v-for="tab in pageTabs"
-        :key="tab.href"
-        :href="tab.href"
-        class="px-2 py-1 text-sm"
-        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
-      >
-        {{ tab.title }}
-      </RouterLink>
-    </div>
     <Card pt:content:class="p-0">
       <template #content>
         <Editor v-model="editContent" textOnly placeholder="Start typing for text output..." />

--- a/playground/src/pages/components/editor/Variant.vue
+++ b/playground/src/pages/components/editor/Variant.vue
@@ -1,36 +1,16 @@
 <script setup>
 import { ref } from 'vue';
-import { useRoute } from 'vue-router';
 import Card from '@ui/components/Card.vue';
 import Button from '@ui/components/Button.vue';
 import Editor from '@ui/components/Editor/Index.vue';
 import Content from '@ui/components/Editor/EditorContent.vue';
 import Textarea from '@ui/components/Textarea.vue';
-import RouterLink from '../../../components/RouterLink.vue';
 
-const route = useRoute();
 const editContent = ref('');
-
-const pageTabs = [
-  { title: 'Overview', href: '/components/editor' },
-  { title: 'Variants', href: '/components/editor/variant' },
-  { title: 'Text', href: '/components/editor/text' },
-];
 </script>
 
 <template>
   <section class="p-4 space-y-4">
-    <div class="flex space-x-4 border-b pb-2 mb-4">
-      <RouterLink
-        v-for="tab in pageTabs"
-        :key="tab.href"
-        :href="tab.href"
-        class="px-2 py-1 text-sm"
-        :class="route.path === tab.href ? 'border-b-2 border-primary-500' : 'text-surface-500'"
-      >
-        {{ tab.title }}
-      </RouterLink>
-    </div>
     <Card pt:content:class="p-0">
       <template #content>
         <Editor v-model="editContent" placeholder="Start typing..." />


### PR DESCRIPTION
## Summary
- include Editor route in components side nav
- drive Editor examples with PageHeader tabs

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a9cf60b8d48325b5a953615796b546