### PR TITLE
fix: hide InputText clear icon when disabled

### DIFF
--- a/ui/src/components/InputText.vue
+++ b/ui/src/components/InputText.vue
@@ -10,10 +10,11 @@
                 :ptOptions="{ mergeProps: ptViewMerge }"
             />
             <button
-                v-if="model && !props.disabled && clearable"
+                v-if="model && clearable"
                 type="button"
                 @click="clearInput"
-                class="absolute top-1/2 -translate-y-1/2 right-3 text-surface-400 hover:text-surface-600 dark:text-surface-300 dark:hover:text-white cursor-pointer"
+                :disabled="isDisabled"
+                class="absolute top-1/2 -translate-y-1/2 right-3 text-surface-400 hover:text-surface-600 dark:text-surface-300 dark:hover:text-white cursor-pointer disabled:hidden disabled:pointer-events-none"
             >
                 <TimesIcon class="w-4 h-4" />
             </button>
@@ -71,5 +72,6 @@ const passThroughProps = computed(() => {
     return rest;
 });
 const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const isDisabled = computed(() => !!bindProps.value.disabled);
 </script>
 

--- a/ui/tests/components/InputText.test.ts
+++ b/ui/tests/components/InputText.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import InputText from '../../src/components/InputText.vue';
+
+const mountWithPrime = (props: any = {}) =>
+    mount(InputText, {
+        global: { plugins: [PrimeVue] },
+        props,
+    });
+
+describe('InputText', () => {
+    it('hides clear button when disabled', async () => {
+        const wrapper = mountWithPrime({ modelValue: 'test', clearable: true, disabled: true });
+        const button = wrapper.find('button');
+        expect(button.exists()).toBe(true);
+        expect(button.attributes('disabled')).not.toBeUndefined();
+        expect(button.classes()).toContain('disabled:hidden');
+        await button.trigger('click');
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- hide InputText clear icon on disabled fields and prevent clicks
- add test covering disabled InputText clear icon behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9d1c7e54483258c2951c8983a1163