### PR TITLE
Align Select height with InputText

### DIFF
--- a/ui/src/components/Select.vue
+++ b/ui/src/components/Select.vue
@@ -53,14 +53,16 @@ const theme = ref<SelectPassThroughOptions>({
         p-invalid:border-red-400 dark:p-invalid:border-red-500
         p-disabled:bg-surface-200 p-disabled:text-surface-500 dark:p-disabled:bg-surface-700 dark:p-disabled:text-surface-400 p-disabled:pointer-events-none p-disabled:opacity-70
         transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`,
-    label: `flex items-center px-3 py-[9px]
-        leading-[1.25rem]
+    label: `flex items-center px-3 py-2.5
+        leading-6
         whitespace-nowrap overflow-hidden flex-auto w-[1%]
         overflow-ellipsis
         p-clearable:pe-7 p-empty:overflow-hidden p-empty:opacity-0 p-editable:cursor-default
         text-surface-700 dark:text-surface-0 bg-transparent border-none outline-none
         p-placeholder:text-surface-500 dark:p-placeholder:text-surface-400
-        p-disabled:text-surface-500 dark:p-disabled:text-surface-400`,
+        p-disabled:text-surface-500 dark:p-disabled:text-surface-400
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem] p-small:leading-5
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem] p-large:leading-7`,
     dropdown: `flex items-center justify-center shrink-0 bg-transparent
         text-surface-400 w-10 rounded-e`,
     overlay: `absolute top-0 left-0 rounded-md p-portal-self:min-w-full


### PR DESCRIPTION
## Summary
- adjust Select component styles to match InputText height
- include small and large padding and line-height options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9d30a3fc083258b7b116f9e794633