### PR TITLE
fix(playground): display component demos

### DIFF
--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -11,7 +11,7 @@ const dialogVisible = ref(false);
 
 <template>
   <section class="p-4 space-y-4">
-    <Card :pt="{ root: 'p-0' }">
+    <Card pt.content="p-0">
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
           Drawer
@@ -25,7 +25,7 @@ const dialogVisible = ref(false);
       </Drawer>
     </Card>
 
-    <Card :pt="{ root: 'p-0' }">
+    <Card pt.content="p-0">
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
           Modal

--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -17,12 +17,14 @@ const dialogVisible = ref(false);
           Drawer
         </div>
       </template>
-      <div class="p-4">
-        <Button label="Open Drawer" @click="drawerVisible = true" />
-      </div>
-      <Drawer v-model:visible="drawerVisible" header="Drawer">
-        <p class="m-0 p-4">Drawer Content</p>
-      </Drawer>
+      <template #content>
+        <div class="p-4">
+          <Button label="Open Drawer" @click="drawerVisible = true" />
+        </div>
+        <Drawer v-model:visible="drawerVisible" header="Drawer">
+          <p class="m-0 p-4">Drawer Content</p>
+        </Drawer>
+      </template>
     </Card>
 
     <Card pt.content="p-0">
@@ -31,15 +33,17 @@ const dialogVisible = ref(false);
           Modal
         </div>
       </template>
-      <div class="p-4">
-        <Button label="Open Modal" @click="dialogVisible = true" />
-      </div>
-      <Dialog v-model:visible="dialogVisible" header="Modal">
-        <p class="m-0 p-4">Modal Content</p>
-        <template #footer>
-          <Button label="Close" @click="dialogVisible = false" />
-        </template>
-      </Dialog>
+      <template #content>
+        <div class="p-4">
+          <Button label="Open Modal" @click="dialogVisible = true" />
+        </div>
+        <Dialog v-model:visible="dialogVisible" header="Modal">
+          <p class="m-0 p-4">Modal Content</p>
+          <template #footer>
+            <Button label="Close" @click="dialogVisible = false" />
+          </template>
+        </Dialog>
+      </template>
     </Card>
   </section>
 </template>

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -18,7 +18,7 @@ const users = ref([
 
 <template>
   <section class="p-4 space-y-4">
-    <Card :pt="{ root: 'p-0' }">
+    <Card pt.content="p-0">
       <DataTable :value="users" paginator :rows="5">
         <Column field="name" header="Name" />
         <Column field="email" header="Email" />

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -19,11 +19,13 @@ const users = ref([
 <template>
   <section class="p-4 space-y-4">
     <Card pt.content="p-0">
-      <DataTable :value="users" paginator :rows="5">
-        <Column field="name" header="Name" />
-        <Column field="email" header="Email" />
-        <Column field="country" header="Country" />
-      </DataTable>
+      <template #content>
+        <DataTable :value="users" paginator :rows="5">
+          <Column field="name" header="Name" />
+          <Column field="email" header="Email" />
+          <Column field="country" header="Country" />
+        </DataTable>
+      </template>
     </Card>
   </section>
 </template>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -13,7 +13,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
 
 <template>
   <section class="p-4 space-y-4">
-    <Card :pt="{ root: 'p-0' }">
+    <Card pt.content="p-0">
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
           <div>Accordion</div>
@@ -46,7 +46,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
             </AccordionPanel>
           </Accordion>
         </Card>
-      <Card :pt="{ root: 'p-0' }">
+      <Card pt.content="p-0">
         <template #header>
           <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
             <div>Tabs</div>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -19,63 +19,67 @@ import TabPanel from '@ui/components/TabPanel.vue';
           <div>Accordion</div>
         </div>
       </template>
+      <template #content>
         <Accordion value="0">
-            <AccordionPanel value="0">
-              <AccordionHeader>Header I</AccordionHeader>
-              <AccordionContent>
-                <p class="m-0">
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                </p>
-              </AccordionContent>
-            </AccordionPanel>
-            <AccordionPanel value="1">
-              <AccordionHeader>Header II</AccordionHeader>
-              <AccordionContent>
-                <p class="m-0">
-                  Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
-                </p>
-              </AccordionContent>
-            </AccordionPanel>
-            <AccordionPanel value="2" disabled>
-              <AccordionHeader>Header III (disabled)</AccordionHeader>
-              <AccordionContent>
-                <p class="m-0">
-                  At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
-                </p>
-              </AccordionContent>
-            </AccordionPanel>
-          </Accordion>
-        </Card>
-      <Card pt.content="p-0">
-        <template #header>
-          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
-            <div>Tabs</div>
-          </div>
-        </template>
-          <Tabs value="0">
-            <TabList>
-              <Tab value="0">Header I</Tab>
-              <Tab value="1">Header II</Tab>
-              <Tab value="2">Header III</Tab>
-            </TabList>
-            <TabPanels>
-              <TabPanel value="0">
-                <p class="m-0">
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </p>
-              </TabPanel>
-              <TabPanel value="1">
-                <p class="m-0">
-                  Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </p>
-              </TabPanel>
-              <TabPanel value="2">
-                <p class="m-0">
-                  At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </p>
-              </TabPanel>
-            </TabPanels>
-            </Tabs>
-        </Card>
-    </section>
-  </template>
+          <AccordionPanel value="0">
+            <AccordionHeader>Header I</AccordionHeader>
+            <AccordionContent>
+              <p class="m-0">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </p>
+            </AccordionContent>
+          </AccordionPanel>
+          <AccordionPanel value="1">
+            <AccordionHeader>Header II</AccordionHeader>
+            <AccordionContent>
+              <p class="m-0">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+              </p>
+            </AccordionContent>
+          </AccordionPanel>
+          <AccordionPanel value="2" disabled>
+            <AccordionHeader>Header III (disabled)</AccordionHeader>
+            <AccordionContent>
+              <p class="m-0">
+                At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+              </p>
+            </AccordionContent>
+          </AccordionPanel>
+        </Accordion>
+      </template>
+    </Card>
+    <Card pt.content="p-0">
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
+          <div>Tabs</div>
+        </div>
+      </template>
+      <template #content>
+        <Tabs value="0">
+          <TabList>
+            <Tab value="0">Header I</Tab>
+            <Tab value="1">Header II</Tab>
+            <Tab value="2">Header III</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel value="0">
+              <p class="m-0">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+              </p>
+            </TabPanel>
+            <TabPanel value="1">
+              <p class="m-0">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+              </p>
+            </TabPanel>
+            <TabPanel value="2">
+              <p class="m-0">
+                At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+              </p>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </template>
+    </Card>
+  </section>
+</template>


### PR DESCRIPTION
## Summary
- ensure tables, tabs, and overlays demos render content
- use Card `pt.content` to strip padding without extra root props

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9d115a6a88325a1dc84e57dc4f8cf