### PR TITLE
feat(playground): add sizing tab for forms

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -33,6 +33,12 @@ const sideBarItems = computed(() => [
   });
 
   const pageTabs = computed(() => {
+    if (route.path.startsWith('/components/forms')) {
+      return [
+        { title: 'General', href: '/components/forms' },
+        { title: 'Sizing', href: '/components/forms/sizing' },
+      ];
+    }
     if (route.path.startsWith('/components/editor')) {
       return [
         { title: 'Overview', href: '/components/editor' },

--- a/playground/src/pages/components/Forms.vue
+++ b/playground/src/pages/components/Forms.vue
@@ -14,6 +14,11 @@ import Alert from '@ui/components/Alert.vue';
 import LabelChoice from '@ui/components/LabelChoice.vue';
 import RadioButton from '@ui/components/RadioButton.vue';
 import Checkbox from '@ui/components/Checkbox.vue';
+import Tabs from '@ui/components/Tabs.vue';
+import TabList from '@ui/components/TabList.vue';
+import Tab from '@ui/components/Tab.vue';
+import TabPanels from '@ui/components/TabPanels.vue';
+import TabPanel from '@ui/components/TabPanel.vue';
 import { useModal } from '@ui/composables';
 
 const { open } = useModal();
@@ -108,7 +113,14 @@ const search = (event) => {
 
 <template>
   <section class="p-4 space-y-4">
-    <div class="flex flex-col space-y-4">
+    <Tabs value="0">
+      <TabList>
+        <Tab value="0">General</Tab>
+        <Tab value="1">Sizing</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel value="0">
+          <div class="flex flex-col space-y-4">
       <div class="flex space-x-4">
         <Card>
           <template #header>
@@ -254,10 +266,9 @@ const search = (event) => {
             </div>
           </template>
           <template #footer>
-            <div class="flex items-center space-x-4">
-              <Button label="Save" @click="open('TEST')" />
-              <Button outlined label="Show blank" @click="open('BLANK_DRAWER')" />
-            </div>
+              <div class="flex items-center space-x-4">
+                <Button label="Save" @click="open('TEST')" />
+              </div>
           </template>
         </Card>
         <Card>
@@ -312,15 +323,58 @@ const search = (event) => {
             </div>
           </template>
           <template #footer>
-            <div class="flex items-center space-x-4">
-              <Button label="Save" @click="open('TEST')" :disabled="true" />
-              <Button outlined label="Show blank" @click="open('BLANK_DRAWER')" :disabled="true" />
+              <div class="flex items-center space-x-4">
+                <Button label="Save" @click="open('TEST')" :disabled="true" />
+              </div>
+          </template>
+        </Card>
+      </div>
+      </div>
+    </TabPanel>
+    <TabPanel value="1">
+      <div class="space-y-4">
+        <Card class="w-full">
+          <template #content>
+            <div class="space-y-4">
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                <LabelField name="first_name" label="First Name">
+                  <InputText v-model="form.first_name" fluid />
+                </LabelField>
+                <LabelField name="last_name" label="Last Name">
+                  <InputText v-model="form.last_name" fluid />
+                </LabelField>
+                <LabelField name="email" label="Email">
+                  <InputText v-model="form.email" fluid />
+                </LabelField>
+                <LabelField name="type" label="Type">
+                  <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid />
+                </LabelField>
+              </div>
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                <LabelField name="amount" label="Amount">
+                  <InputNumber v-model="form.amount" mode="currency" currency="USD" locale="en-US" fluid placeholder="$0.00" />
+                </LabelField>
+                <LabelField name="roles" label="Roles">
+                  <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid />
+                </LabelField>
+                <LabelField name="autorole" label="Auto Role">
+                  <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear />
+                </LabelField>
+                <LabelField name="gender" label="Gender">
+                  <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid />
+                </LabelField>
+              </div>
+              <div class="flex items-center space-x-4">
+                <Button outlined label="Cancel" />
+                <Button label="Save" />
+              </div>
             </div>
           </template>
         </Card>
       </div>
-      
-    </div>
+    </TabPanel>
+  </TabPanels>
+    </Tabs>
   </section>
 </template>
 

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -14,11 +14,6 @@ import Alert from '@ui/components/Alert.vue';
 import LabelChoice from '@ui/components/LabelChoice.vue';
 import RadioButton from '@ui/components/RadioButton.vue';
 import Checkbox from '@ui/components/Checkbox.vue';
-import Tabs from '@ui/components/Tabs.vue';
-import TabList from '@ui/components/TabList.vue';
-import Tab from '@ui/components/Tab.vue';
-import TabPanels from '@ui/components/TabPanels.vue';
-import TabPanel from '@ui/components/TabPanel.vue';
 import { useModal } from '@ui/composables';
 
 const { open } = useModal();
@@ -113,14 +108,7 @@ const search = (event) => {
 
 <template>
   <section class="p-4 space-y-4">
-    <Tabs value="0">
-      <TabList>
-        <Tab value="0">General</Tab>
-        <Tab value="1">Sizing</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel value="0">
-          <div class="flex flex-col space-y-4">
+    <div class="flex flex-col space-y-4">
       <div class="flex space-x-4">
         <Card>
           <template #header>
@@ -329,52 +317,7 @@ const search = (event) => {
           </template>
         </Card>
       </div>
-      </div>
-    </TabPanel>
-    <TabPanel value="1">
-      <div class="space-y-4">
-        <Card class="w-full">
-          <template #content>
-            <div class="space-y-4">
-              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                <LabelField name="first_name" label="First Name">
-                  <InputText v-model="form.first_name" fluid />
-                </LabelField>
-                <LabelField name="last_name" label="Last Name">
-                  <InputText v-model="form.last_name" fluid />
-                </LabelField>
-                <LabelField name="email" label="Email">
-                  <InputText v-model="form.email" fluid />
-                </LabelField>
-                <LabelField name="type" label="Type">
-                  <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid />
-                </LabelField>
-              </div>
-              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                <LabelField name="amount" label="Amount">
-                  <InputNumber v-model="form.amount" mode="currency" currency="USD" locale="en-US" fluid placeholder="$0.00" />
-                </LabelField>
-                <LabelField name="roles" label="Roles">
-                  <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid />
-                </LabelField>
-                <LabelField name="autorole" label="Auto Role">
-                  <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear />
-                </LabelField>
-                <LabelField name="gender" label="Gender">
-                  <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid />
-                </LabelField>
-              </div>
-              <div class="flex items-center space-x-4">
-                <Button outlined label="Cancel" />
-                <Button label="Save" />
-              </div>
-            </div>
-          </template>
-        </Card>
-      </div>
-    </TabPanel>
-  </TabPanels>
-    </Tabs>
+    </div>
   </section>
 </template>
 

--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -1,0 +1,128 @@
+<script setup>
+import { ref, reactive } from 'vue';
+import Card from '@ui/components/Card.vue';
+import LabelField from '@ui/components/LabelField.vue';
+import InputText from '@ui/components/InputText.vue';
+import Select from '@ui/components/Select.vue';
+import MultiSelect from '@ui/components/MultiSelect.vue';
+import AutoComplete from '@ui/components/AutoComplete.vue';
+import InputNumber from '@ui/components/InputNumber.vue';
+import Button from '@ui/components/Button.vue';
+
+const form = reactive({
+  first_name: 'John',
+  last_name: null,
+  amount: null,
+  email: 'example@example.com',
+  roles: [],
+  type: 'credit',
+  payment: 'disabled',
+  agree: false,
+  checked: 'on',
+  gender: null,
+  autorole: null,
+});
+
+const roles = ref([
+  { id: 'admin', name: 'Admin' },
+  { id: 'user', name: 'User' },
+  { id: 'guest', name: 'Guest' },
+  { id: 'banned', name: 'Banned' },
+  { id: 'pending', name: 'Pending' },
+  { id: 'suspended', name: 'Suspended' },
+  { id: 'deleted', name: 'Deleted' },
+  { id: 'blacklisted', name: 'Blacklisted' },
+  { id: 'archived', name: 'Archived' },
+]);
+
+const genders = ref([
+  { id: 'male', gender: 'Male' },
+  { id: 'female', gender: 'Female' },
+  { id: 'other', gender: 'Other' },
+]);
+
+const autoRoles = ref([
+  { id: 'admin', label: 'Admin' },
+  { id: 'user', label: 'User' },
+  { id: 'guest', label: 'Guest' },
+  { id: 'banned', label: 'Banned' },
+  { id: 'pending', label: 'Pending' },
+  { id: 'suspended', label: 'Suspended' },
+  { id: 'deleted', label: 'Deleted' },
+  { id: 'blacklisted', label: 'Blacklisted' },
+  { id: 'archived', label: 'Archived' },
+]);
+
+const types = ref([
+  { id: 'credit', name: 'Credit' },
+  { id: 'debit', name: 'Debit' },
+  { id: 'transfer', name: 'Transfer' },
+  { id: 'deposit', name: 'Deposit' },
+]);
+
+const filteredRoles = ref([...autoRoles.value]);
+
+const search = (event) => {
+  setTimeout(() => {
+    if (!event.query.trim().length) {
+      filteredRoles.value = [...autoRoles.value];
+    } else {
+      filteredRoles.value = autoRoles.value.filter((country) => {
+        return country.label.toLowerCase().startsWith(event.query.toLowerCase());
+      });
+    }
+  }, 250);
+};
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <Card class="w-full">
+      <template #content>
+        <div class="space-y-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <LabelField name="first_name" label="First Name">
+              <InputText v-model="form.first_name" fluid />
+            </LabelField>
+            <LabelField name="last_name" label="Last Name">
+              <InputText v-model="form.last_name" fluid />
+            </LabelField>
+            <LabelField name="email" label="Email">
+              <InputText v-model="form.email" fluid />
+            </LabelField>
+            <LabelField name="type" label="Type">
+              <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid />
+            </LabelField>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <LabelField name="amount" label="Amount">
+              <InputNumber v-model="form.amount" mode="currency" currency="USD" locale="en-US" fluid placeholder="$0.00" />
+            </LabelField>
+            <LabelField name="roles" label="Roles">
+              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid />
+            </LabelField>
+            <LabelField name="autorole" label="Auto Role">
+              <AutoComplete
+                v-model="form.autorole"
+                :suggestions="filteredRoles"
+                @complete="search"
+                optionLabel="label"
+                optionValue="id"
+                fluid
+                dropdown
+                showClear
+              />
+            </LabelField>
+            <LabelField name="gender" label="Gender">
+              <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid />
+            </LabelField>
+          </div>
+          <div class="flex items-center space-x-4">
+            <Button outlined label="Cancel" />
+            <Button label="Save" />
+          </div>
+        </div>
+      </template>
+    </Card>
+  </section>
+</template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -3,7 +3,8 @@ import Home from './pages/Home.vue';
 import Users from './pages/Users.vue';
 import ComponentsLayout from './pages/components/Index.vue';
 import Buttons from './pages/components/Buttons.vue';
-import Forms from './pages/components/Forms.vue';
+import Forms from './pages/components/forms/Index.vue';
+import FormsSizing from './pages/components/forms/Sizing.vue';
 import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
 import Overlays from './pages/components/Overlays.vue';
@@ -21,6 +22,7 @@ const routes = [
     children: [
       { path: 'buttons', component: Buttons, meta: { title: 'Buttons' } },
       { path: 'forms', component: Forms, meta: { title: 'Forms' } },
+      { path: 'forms/sizing', component: FormsSizing, meta: { title: 'Forms' } },
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
       { path: 'overlays', component: Overlays, meta: { title: 'Overlays' } },


### PR DESCRIPTION
## Summary
- add General/Sizing tabs to forms playground
- remove unused "show blank" actions
- demo responsive field sizing

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a9d3be9114832586516d29867a09a5