### PR TITLE
feat: add grouped page side nav items for testing

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -24,8 +24,47 @@ const sideBarItems = computed(() => [
         { label: 'Forms', href: '/components/forms' },
         { label: 'Tables', href: '/components/tables' },
         { label: 'Tabs', href: '/components/tabs' },
-          { label: 'Overlays', href: '/components/overlays' },
+        { label: 'Overlays', href: '/components/overlays' },
         { label: 'Editor', href: '/components/editor', parent: '/components/editor' },
+        {
+          label: 'My Account',
+          children: [
+            { label: 'Account', href: '/account' },
+            { label: 'Security', href: '/account/security' },
+          ],
+        },
+        {
+          label: 'Notifications',
+          children: [
+            { label: 'Email', href: '/notifications/email' },
+            { label: 'Push', href: '/notifications/push' },
+          ],
+        },
+        {
+          label: 'Security',
+          children: [
+            { label: 'Password', href: '/security/password' },
+            { label: 'Two Factor', href: '/security/two-factor' },
+          ],
+        },
+        {
+          label: 'Billing',
+          children: [
+            { label: 'Plans', href: '/billing/plans' },
+            { label: 'Invoices', href: '/billing/invoices' },
+            { label: 'Subscriptions', href: '/billing/subscriptions' },
+          ],
+        },
+        {
+          label: 'Integrations',
+          children: [
+            { label: 'Google', href: '/integrations/google' },
+            { label: 'Slack', href: '/integrations/slack' },
+            { label: 'Dropbox', href: '/integrations/dropbox' },
+            { label: 'Mailchimp', href: '/integrations/mailchimp' },
+            { label: 'Stripe', href: '/integrations/stripe' },
+          ],
+        },
       ];
     }
 

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -20,17 +20,15 @@ const sideBarItems = computed(() => [
   const pageNavItems = computed(() => {
     if (route.path.startsWith('/components')) {
       return [
-        { label: 'Buttons', href: '/components/buttons' },
-        { label: 'Forms', href: '/components/forms' },
-        { label: 'Tables', href: '/components/tables' },
-        { label: 'Tabs', href: '/components/tabs' },
-        { label: 'Overlays', href: '/components/overlays' },
-        { label: 'Editor', href: '/components/editor', parent: '/components/editor' },
         {
-          label: 'My Account',
+          label: 'Components',
           children: [
-            { label: 'Account', href: '/account' },
-            { label: 'Security', href: '/account/security' },
+              { label: 'Buttons', href: '/components/buttons' },
+              { label: 'Forms', href: '/components/forms' },
+              { label: 'Tables', href: '/components/tables' },
+              { label: 'Tabs', href: '/components/tabs' },
+              { label: 'Overlays', href: '/components/overlays' },
+              { label: 'Editor', href: '/components/editor', parent: '/components/editor' },
           ],
         },
         {
@@ -53,16 +51,6 @@ const sideBarItems = computed(() => [
             { label: 'Plans', href: '/billing/plans' },
             { label: 'Invoices', href: '/billing/invoices' },
             { label: 'Subscriptions', href: '/billing/subscriptions' },
-          ],
-        },
-        {
-          label: 'Integrations',
-          children: [
-            { label: 'Google', href: '/integrations/google' },
-            { label: 'Slack', href: '/integrations/slack' },
-            { label: 'Dropbox', href: '/integrations/dropbox' },
-            { label: 'Mailchimp', href: '/integrations/mailchimp' },
-            { label: 'Stripe', href: '/integrations/stripe' },
           ],
         },
       ];


### PR DESCRIPTION
## Summary
- add grouped navigation sections to playground page side nav for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9d67a3c348325b90805fb08e31519