### PR TITLE
feat(ui): add card no padding option

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -454,6 +454,10 @@ import { Card } from '@atlas/ui';
 <Card title="Title">Content</Card>
 ```
 
+##### Props
+
+- `noPadding` – removes padding from the card's content section.
+
 ##### API
 
 Refer to the [PrimeVue Card API](https://primevue.org/card/#api).

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -18,7 +18,7 @@ const users = ref([
 
 <template>
   <section class="p-4 space-y-4">
-    <Card pt.content="p-0">
+    <Card noPadding>
       <template #content>
         <DataTable :value="users" paginator :rows="5">
           <Column field="name" header="Name" />

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -13,7 +13,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
 
 <template>
   <section class="p-4 space-y-4">
-    <Card pt.content="p-0">
+    <Card noPadding>
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
           <div>Accordion</div>
@@ -48,7 +48,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
         </Accordion>
       </template>
     </Card>
-    <Card pt.content="p-0">
+    <Card noPadding>
       <template #header>
         <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center space-x-2">
           <div>Tabs</div>

--- a/ui/src/components/Card.vue
+++ b/ui/src/components/Card.vue
@@ -13,14 +13,19 @@
 
 <script setup lang="ts">
 import Card, { type CardPassThroughOptions, type CardProps } from 'primevue/card';
-import { ref, useAttrs, computed } from 'vue';
+import { useAttrs, computed } from 'vue';
 import { ptViewMerge, ptMerge } from '../utils';
 
-interface Props extends /* @vue-ignore */ CardProps {}
-const props = defineProps<Props>();
+interface Props extends /* @vue-ignore */ CardProps {
+    noPadding?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    noPadding: false,
+});
 const attrs = useAttrs();
 
-const theme = ref<CardPassThroughOptions>({
+const theme = computed<CardPassThroughOptions>(() => ({
     root: `flex flex-col rounded-lg
         bg-surface-0 dark:bg-surface-800
         text-surface-700 dark:text-surface-0
@@ -31,13 +36,13 @@ const theme = ref<CardPassThroughOptions>({
     caption: `flex flex-col gap-2`,
     title: `font-semibold text-lg px-6 py-4`,
     subtitle: `text-surface-500 dark:text-surface-400`,
-    content: `p-6 h-full`,
+    content: `${props.noPadding ? '' : 'p-6'} h-full`,
     footer: `p-6 py-4 border-t border-surface-300 dark:border-surface-700`
-});
+}));
 
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
+    const { pt, noPadding, ...rest } = props as any;
     return rest;
 });
 const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));

--- a/ui/tests/components/Card.test.ts
+++ b/ui/tests/components/Card.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import Card from '../../src/components/Card.vue';
+
+const mountWithPrime = (props: any = {}, slots: any = {}) =>
+    mount(Card, {
+        global: { plugins: [PrimeVue] },
+        props,
+        slots,
+    });
+
+describe('Card', () => {
+    it('has default content padding', () => {
+        const wrapper = mountWithPrime({}, { content: 'Content' });
+        const content = wrapper.find('[data-pc-section="content"]');
+        expect(content.classes()).toContain('p-6');
+    });
+
+    it('removes content padding when noPadding is true', () => {
+        const wrapper = mountWithPrime({ noPadding: true }, { content: 'Content' });
+        const content = wrapper.find('[data-pc-section="content"]');
+        expect(content.classes()).not.toContain('p-6');
+    });
+});


### PR DESCRIPTION
## Summary
- add `noPadding` prop to Card to strip content padding
- document Card no padding option and update tables/tabs examples
- test card padding behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9d611a1308325b2ad93164399b232