### PR TITLE
fix(playground): load primeui tailwind plugin

### DIFF
--- a/playground/tailwind.config.js
+++ b/playground/tailwind.config.js
@@ -1,8 +1,11 @@
 /** @type {import('tailwindcss').Config} */
+import primeui from 'tailwindcss-primeui';
+
 export default {
   content: [
       './index.html',
       './src/**/*.{vue,js,ts,jsx,tsx}',
       '../ui/src/**/*.{vue,js,ts,jsx,tsx}',
   ],
+  plugins: [primeui],
 }


### PR DESCRIPTION
## Summary
- enable tailwindcss-primeui plugin for playground so PrimeVue form components render with custom styling

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a9d57c3050832580bab27f3a2175e3