### PR TITLE
feat: expand form sizing examples

### DIFF
--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -21,7 +21,14 @@ const form = reactive({
   checked: 'on',
   gender: null,
   autorole: null,
+  query: null,
 });
+
+const formSizes = [
+  { label: 'Default', size: undefined },
+  { label: 'Small', size: 'small' },
+  { label: 'Large', size: 'large' },
+];
 
 const roles = ref([
   { id: 'admin', name: 'Admin' },
@@ -77,29 +84,46 @@ const search = (event) => {
 
 <template>
   <section class="p-4 space-y-4">
-    <Card class="w-full">
+    <Card v-for="item in formSizes" :key="item.label" class="w-full">
+      <template #header>
+        <span>{{ item.label }}</span>
+      </template>
       <template #content>
         <div class="space-y-4">
+          <div class="flex items-end space-x-4">
+            <LabelField name="query" label="Query" class="flex-1">
+              <InputText v-model="form.query" fluid :size="item.size" />
+            </LabelField>
+            <Button label="Search" :size="item.size" />
+          </div>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <LabelField name="first_name" label="First Name">
-              <InputText v-model="form.first_name" fluid />
+              <InputText v-model="form.first_name" fluid :size="item.size" />
             </LabelField>
             <LabelField name="last_name" label="Last Name">
-              <InputText v-model="form.last_name" fluid />
+              <InputText v-model="form.last_name" fluid :size="item.size" />
             </LabelField>
             <LabelField name="email" label="Email">
-              <InputText v-model="form.email" fluid />
+              <InputText v-model="form.email" fluid :size="item.size" />
             </LabelField>
             <LabelField name="type" label="Type">
-              <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid />
+              <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid :size="item.size" />
             </LabelField>
           </div>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <LabelField name="amount" label="Amount">
-              <InputNumber v-model="form.amount" mode="currency" currency="USD" locale="en-US" fluid placeholder="$0.00" />
+              <InputNumber
+                v-model="form.amount"
+                mode="currency"
+                currency="USD"
+                locale="en-US"
+                fluid
+                placeholder="$0.00"
+                :size="item.size"
+              />
             </LabelField>
             <LabelField name="roles" label="Roles">
-              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid />
+              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid :size="item.size" />
             </LabelField>
             <LabelField name="autorole" label="Auto Role">
               <AutoComplete
@@ -111,15 +135,16 @@ const search = (event) => {
                 fluid
                 dropdown
                 showClear
+                :size="item.size"
               />
             </LabelField>
             <LabelField name="gender" label="Gender">
-              <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid />
+              <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid :size="item.size" />
             </LabelField>
           </div>
           <div class="flex items-center space-x-4">
-            <Button outlined label="Cancel" />
-            <Button label="Save" />
+            <Button outlined label="Cancel" :size="item.size" />
+            <Button label="Save" :size="item.size" />
           </div>
         </div>
       </template>

--- a/ui/src/components/AutoComplete.vue
+++ b/ui/src/components/AutoComplete.vue
@@ -27,7 +27,7 @@ const attrs = useAttrs();
 const theme = ref<AutoCompletePassThroughOptions>({
     root: `inline-flex p-fluid:flex`,
     pcInputText: {
-        root: `appearance-none rounded outline-hidden
+        root: `appearance-none rounded-md outline-hidden
             bg-surface-0 dark:bg-surface-950
             p-filled:bg-surface-50 dark:p-filled:bg-surface-800
             text-surface-700 dark:text-surface-0
@@ -47,7 +47,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     },
     inputMultiple: `m-0 list-none cursor-text overflow-hidden flex items-center flex-wrap
         px-3 py-1 not-p-empty:px-1 gap-1 text-surface-700 dark:text-surface-0 bg-surface-0 dark:bg-surface-950
-        border border-surface-300 dark:border-surface-700 rounded p-has-dropdown:rounded-e-none w-full
+        border border-surface-300 dark:border-surface-700 rounded-md p-has-dropdown:rounded-e-none w-full
         hover:border-surface-400 dark:hover:border-surface-600 p-focus:border-primary
         p-invalid:border-red-400 dark:p-invalid:border-red-300
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
@@ -74,7 +74,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     input: `border-none outline-none bg-transparent m-0 p-0 shadow-none rounded-none w-full text-inherit
         placeholder:text-surface-500 dark:placeholder:text-surface-400`,
     loader: `absolute top-1/2 -mt-2 end-3 p-has-dropdown:end-[3.25rem] animate-spin`,
-    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e
+    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-md
         border border-s-0 border-surface-300 dark:border-surface-700
         bg-surface-100 enabled:hover:bg-surface-200 enabled:active:bg-surface-300
         text-surface-600 enabled:hover:text-surface-700 enabled:hover:active:text-surface-800
@@ -83,7 +83,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         transition-colors duration-200`,
     dropdownIcon: ``,
-    overlay: `p-portal-self:min-w-full absolute top-0 left-0 rounded
+    overlay: `p-portal-self:min-w-full absolute top-0 left-0 rounded-md
         bg-surface-0 dark:bg-surface-900
         border border-surface-200 dark:border-surface-700
         text-surface-700 dark:text-surface-0


### PR DESCRIPTION
## Summary
- demo default, small, and large form controls with side-by-side input and button
- align AutoComplete rounding with InputText for consistent corners

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9db31fae4832597df8adadde7f756