### PR TITLE
fix(ui): enable PrimeVue tooltips in TooltipIcon

### DIFF
--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <span :title="text" :class="mergedPt.root.class">
+    <span v-tooltip="text" :class="mergedPt.root.class">
         <IconInfoCircle :class="mergedPt.icon.class" />
     </span>
 </template>


### PR DESCRIPTION
## Summary
- use PrimeVue `v-tooltip` directive in `TooltipIcon`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9de9053b88325a0624928706b7a63