### PR TITLE
chore: simplify query field on forms sizing page

### DIFF
--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -93,9 +93,7 @@ const search = (event) => {
       <template #content>
         <div class="space-y-4">
           <div class="flex items-end space-x-4">
-            <LabelField name="query" label="Query" class="flex-1">
-              <InputText v-model="form.query" fluid :size="item.size" />
-            </LabelField>
+            <InputText v-model="form.query" fluid :size="item.size" class="flex-1" />
             <Button label="Search" :size="item.size" />
           </div>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- remove query label for a cleaner forms sizing example

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9e0875a3483259bce7dbfa62b113a