### PR TITLE
fix: ensure checkbox and radio use PrimeVue components

### DIFF
--- a/ui/src/components/Checkbox.vue
+++ b/ui/src/components/Checkbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <Checkbox
+    <PrimeCheckbox
         unstyled
         v-bind="bindProps"
         :pt="mergedPt"
@@ -9,13 +9,13 @@
             <CheckIcon v-if="checked" :class="theme.icon" :data-p="dataP" />
             <MinusIcon v-else-if="indeterminate" :class="theme.icon" :data-p="dataP" />
         </template>
-    </Checkbox>
+    </PrimeCheckbox>
 </template>
 
 <script setup lang="ts">
 import CheckIcon from '@primevue/icons/check';
 import MinusIcon from '@primevue/icons/minus';
-import Checkbox, { type CheckboxPassThroughOptions, type CheckboxProps } from 'primevue/checkbox';
+import PrimeCheckbox, { type CheckboxPassThroughOptions, type CheckboxProps } from 'primevue/checkbox';
 import { ref, useAttrs, computed } from 'vue';
 import { ptViewMerge, ptMerge } from '../utils';
 

--- a/ui/src/components/RadioButton.vue
+++ b/ui/src/components/RadioButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <RadioButton
+    <PrimeRadioButton
         unstyled
         v-bind="bindProps"
         :pt="mergedPt"
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import RadioButton, { type RadioButtonPassThroughOptions, type RadioButtonProps } from 'primevue/radiobutton';
+import PrimeRadioButton, { type RadioButtonPassThroughOptions, type RadioButtonProps } from 'primevue/radiobutton';
 import { ref, useAttrs, computed } from 'vue';
 import { ptViewMerge, ptMerge } from '../utils';
 


### PR DESCRIPTION
## Summary
- use explicit PrimeVue component imports for Checkbox and RadioButton wrappers

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9df71a1e88325bd425c13c46b371d