### PR TITLE
Show error states across form inputs

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -64,6 +64,7 @@ const sideBarItems = computed(() => [
       return [
         { title: 'General', href: '/components/forms' },
         { title: 'Sizing', href: '/components/forms/sizing' },
+        { title: 'Errors', href: '/components/forms/errors' },
       ];
     }
     if (route.path.startsWith('/components/editor')) {

--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -1,0 +1,159 @@
+<script setup>
+import { ref, reactive } from 'vue';
+import Card from '@ui/components/Card.vue';
+import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
+import Button from '@ui/components/Button.vue';
+import ButtonMenu from '@ui/components/ButtonMenu.vue';
+import LabelField from '@ui/components/LabelField.vue';
+import InputText from '@ui/components/InputText.vue';
+import Select from '@ui/components/Select.vue';
+import MultiSelect from '@ui/components/MultiSelect.vue';
+import AutoComplete from '@ui/components/AutoComplete.vue';
+import { useModal } from '@ui/composables';
+import Errors from '@ui/components/Errors.vue';
+
+const { open } = useModal();
+
+const form = reactive({
+  first_name: 'John',
+  last_name: null,
+  roles: [],
+  gender: null,
+  autorole: null,
+  checked: 'on',
+});
+
+const errors = reactive({
+  first_name: 'First name is required',
+  last_name: 'Last name is required',
+  gender: 'Gender is required',
+  roles: 'Roles are required',
+  autorole: 'Role is required',
+});
+
+const roles = ref([
+  { id: 'admin', name: 'Admin' },
+  { id: 'user', name: 'User' },
+  { id: 'guest', name: 'Guest' },
+  { id: 'banned', name: 'Banned' },
+  { id: 'pending', name: 'Pending' },
+  { id: 'suspended', name: 'Suspended' },
+  { id: 'deleted', name: 'Deleted' },
+  { id: 'blacklisted', name: 'Blacklisted' },
+  { id: 'archived', name: 'Archived' },
+]);
+
+const genders = ref([
+  { id: 'male', gender: 'Male' },
+  { id: 'female', gender: 'Female' },
+  { id: 'other', gender: 'Other' },
+]);
+
+const autoRoles = ref([
+  { id: 'admin', label: 'Admin' },
+  { id: 'user', label: 'User' },
+  { id: 'guest', label: 'Guest' },
+  { id: 'banned', label: 'Banned' },
+  { id: 'pending', label: 'Pending' },
+  { id: 'suspended', label: 'Suspended' },
+  { id: 'deleted', label: 'Deleted' },
+  { id: 'blacklisted', label: 'Blacklisted' },
+  { id: 'archived', label: 'Archived' },
+]);
+
+const manageItems = [
+  {
+    label: 'Edit',
+    icon: 'text-sm pi pi-pencil',
+    action: 'edit',
+  },
+  {
+    label: 'Download',
+    icon: 'text-sm pi pi-download',
+    action: 'download',
+    disabled: true,
+  },
+  {
+    separator: true,
+  },
+  {
+    label: 'Archive',
+    icon: 'text-sm pi pi-trash',
+    action: 'delete',
+  },
+];
+
+const filteredRoles = ref([...autoRoles.value]);
+
+const search = (event) => {
+  setTimeout(() => {
+    if (!event.query.trim().length) {
+      filteredRoles.value = [...autoRoles.value];
+    } else {
+      filteredRoles.value = autoRoles.value.filter((country) => {
+        return country.label.toLowerCase().startsWith(event.query.toLowerCase());
+      });
+    }
+  }, 250);
+};
+</script>
+
+<template>
+  <section class="p-4 space-y-4">
+    <div class="flex space-x-4">
+      <Card>
+        <template #header>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center justify-between">
+            <div>Edit (errors)</div>
+            <div class="flex items-center space-x-2">
+              <ToggleSwitch v-model="form.checked" true-value="on" false-value="off" />
+              <ButtonMenu :items="manageItems" />
+            </div>
+          </div>
+        </template>
+        <template #content>
+          <div class="space-y-4 w-full">
+            <div class="w-full flex items-center space-x-4">
+              <LabelField name="first_name" label="First Name" required :error="errors.first_name">
+                <InputText id="first_name_invalid" v-model="form.first_name" type="text" fluid clearable :invalid="true" />
+              </LabelField>
+              <LabelField name="last_name" label="Last Name" required :error="errors.last_name">
+                <InputText id="last_name_invalid" placeholder="Last Name" v-model="form.last_name" type="text" fluid :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="gender" label="Gender" :error="errors.gender">
+                <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="roles" label="Roles" :error="errors.roles">
+                <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="roles" label="Roles (chips)" :error="errors.roles">
+                <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="autorole" label="Roles (autocomplete)" :error="errors.autorole">
+                <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
+              </LabelField>
+            </div>
+          </div>
+        </template>
+        <template #footer>
+          <div class="space-y-4 w-full">
+            <Errors :errors="errors" />
+            <div class="flex items-center space-x-4">
+              <Button label="Save" @click="open('TEST')" />
+              <Button label="Cancel" variant="text" />
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+  </section>
+</template>
+

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -14,7 +14,6 @@ import Alert from '@ui/components/Alert.vue';
 import LabelCheckbox from '@ui/components/LabelCheckbox.vue';
 import LabelRadioButton from '@ui/components/LabelRadioButton.vue';
 import { useModal } from '@ui/composables';
-import Errors from '@ui/components/Errors.vue';
 
 const { open } = useModal();
 
@@ -30,14 +29,6 @@ const form = reactive({
     checked: 'on',
     gender: null,
     autorole: null,
-});
-
-const errors = reactive({
-    first_name: 'First name is required',
-    last_name: 'Last name is required',
-    gender: 'Gender is required',
-    roles: 'Roles are required',
-    autorole: 'Role is required'
 });
 
 const roles = ref([
@@ -302,60 +293,6 @@ const search = (event) => {
               <div class="flex items-center space-x-4">
                 <Button label="Save" @click="open('TEST')" :disabled="true" />
               </div>
-          </template>
-        </Card>
-      </div>
-      <div class="flex space-x-4">
-        <Card>
-          <template #header>
-            <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center justify-between">
-              <div>Edit (errors)</div>
-              <div class="flex items-center space-x-2">
-                <ToggleSwitch v-model="form.checked" true-value="on" false-value="off" />
-                <ButtonMenu :items="manageItems" />
-              </div>
-            </div>
-          </template>
-          <template #content>
-            <div class="space-y-4 w-full">
-              <div class="w-full flex items-center space-x-4">
-                <LabelField name="first_name" label="First Name" required :error="errors.first_name">
-                  <InputText id="first_name_invalid" v-model="form.first_name" type="text" fluid clearable :invalid="true" />
-                </LabelField>
-                <LabelField name="last_name" label="Last Name" required :error="errors.last_name">
-                  <InputText id="last_name_invalid" placeholder="Last Name" v-model="form.last_name" type="text" fluid :invalid="true" />
-                </LabelField>
-              </div>
-              <div class="w-full">
-                <LabelField name="gender" label="Gender" :error="errors.gender">
-                  <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter :invalid="true" />
-                </LabelField>
-              </div>
-              <div class="w-full">
-                <LabelField name="roles" label="Roles" :error="errors.roles">
-                  <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter :invalid="true" />
-                </LabelField>
-              </div>
-              <div class="w-full">
-                <LabelField name="roles" label="Roles (chips)" :error="errors.roles">
-                  <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" :invalid="true" />
-                </LabelField>
-              </div>
-              <div class="w-full">
-                <LabelField name="autorole" label="Roles (autocomplete)" :error="errors.autorole">
-                  <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
-                </LabelField>
-              </div>
-            </div>
-          </template>
-          <template #footer>
-            <div class="space-y-4 w-full">
-              <Errors :errors="errors" />
-              <div class="flex items-center space-x-4">
-                <Button label="Cancel" variant="text" />
-                <Button label="Save" @click="open('TEST')" />
-              </div>
-            </div>
           </template>
         </Card>
       </div>

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -346,7 +346,15 @@ const search = (event) => {
                   <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
                 </LabelField>
               </div>
+            </div>
+          </template>
+          <template #footer>
+            <div class="space-y-4 w-full">
               <Errors :errors="errors" />
+              <div class="flex items-center space-x-4">
+                <Button label="Cancel" variant="text" />
+                <Button label="Save" @click="open('TEST')" />
+              </div>
             </div>
           </template>
         </Card>

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -34,7 +34,10 @@ const form = reactive({
 
 const errors = reactive({
     first_name: 'First name is required',
-    last_name: 'Last name is required'
+    last_name: 'Last name is required',
+    gender: 'Gender is required',
+    roles: 'Roles are required',
+    autorole: 'Role is required'
 });
 
 const roles = ref([
@@ -315,7 +318,6 @@ const search = (event) => {
           </template>
           <template #content>
             <div class="space-y-4 w-full">
-              <Errors :errors="errors" />
               <div class="w-full flex items-center space-x-4">
                 <LabelField name="first_name" label="First Name" required :error="errors.first_name">
                   <InputText id="first_name_invalid" v-model="form.first_name" type="text" fluid clearable :invalid="true" />
@@ -325,30 +327,26 @@ const search = (event) => {
                 </LabelField>
               </div>
               <div class="w-full">
-                <LabelField name="email" label="Email" required>
-                  <InputText id="email_invalid" v-model="form.email" type="text" fluid />
+                <LabelField name="gender" label="Gender" :error="errors.gender">
+                  <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter :invalid="true" />
                 </LabelField>
               </div>
               <div class="w-full">
-                <LabelField name="gender" label="Gender">
-                  <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter />
+                <LabelField name="roles" label="Roles" :error="errors.roles">
+                  <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter :invalid="true" />
                 </LabelField>
               </div>
               <div class="w-full">
-                <LabelField name="roles" label="Roles">
-                  <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter />
+                <LabelField name="roles" label="Roles (chips)" :error="errors.roles">
+                  <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" :invalid="true" />
                 </LabelField>
               </div>
               <div class="w-full">
-                <LabelField name="roles" label="Roles (chips)">
-                  <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" />
+                <LabelField name="autorole" label="Roles (autocomplete)" :error="errors.autorole">
+                  <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
                 </LabelField>
               </div>
-              <div class="w-full">
-                <LabelField name="roles" label="Roles (autocomplete)">
-                  <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection />
-                </LabelField>
-              </div>
+              <Errors :errors="errors" />
             </div>
           </template>
         </Card>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -5,6 +5,7 @@ import ComponentsLayout from './pages/components/Index.vue';
 import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/forms/Index.vue';
 import FormsSizing from './pages/components/forms/Sizing.vue';
+import FormsErrors from './pages/components/forms/Errors.vue';
 import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
 import Overlays from './pages/components/Overlays.vue';
@@ -23,6 +24,7 @@ const routes = [
       { path: 'buttons', component: Buttons, meta: { title: 'Buttons' } },
       { path: 'forms', component: Forms, meta: { title: 'Forms' } },
       { path: 'forms/sizing', component: FormsSizing, meta: { title: 'Forms' } },
+      { path: 'forms/errors', component: FormsErrors, meta: { title: 'Forms' } },
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
       { path: 'overlays', component: Overlays, meta: { title: 'Overlays' } },


### PR DESCRIPTION
## Summary
- demo error states for text, select, multiselect, and autocomplete inputs
- move error summary below form fields in playground example

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9e38faa948325b171daf02cb7f5f5