### PR TITLE
feat(playground): add disabled tab example

### DIFF
--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -59,7 +59,7 @@ import TabPanel from '@ui/components/TabPanel.vue';
           <TabList>
             <Tab value="0">Header I</Tab>
             <Tab value="1">Header II</Tab>
-            <Tab value="2">Header III</Tab>
+            <Tab value="2" disabled>Header III (disabled)</Tab>
           </TabList>
           <TabPanels>
             <TabPanel value="0">


### PR DESCRIPTION
## Summary
- show disabled tab alongside accordion example on tabs page

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a9e539419883259996d321a2df7747