### PR TITLE
feat(ui): align button height with inputs

### DIFF
--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -22,7 +22,7 @@ const attrs = useAttrs();
 
 const theme = ref<ButtonPassThroughOptions>({
     root: `inline-flex self-start cursor-pointer select-none items-center justify-center overflow-hidden relative
-        px-4 py-2.5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
+        px-4 py-[9px] leading-5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
@@ -48,6 +48,7 @@ const theme = ref<ButtonPassThroughOptions>({
     loadingIcon: `animate-spin`,
     icon: `p-right:order-1 p-bottom:order-2`,
     label: `
+            leading-5
             p-icon-only:invisible p-icon-only:w-0
             p-large:font-bold
         `,

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -23,4 +23,12 @@ describe('Button', () => {
         expect(classes).toContain('p-small:px-[0.625rem]');
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
+
+    it('uses 40px default height', () => {
+        const wrapper = mountWithPrime({ label: 'Test' });
+        const classes = wrapper.find('button').attributes('class');
+        expect(classes).toContain('py-[9px]');
+        const labelClasses = wrapper.find('span').attributes('class');
+        expect(labelClasses).toContain('leading-5');
+    });
 });


### PR DESCRIPTION
## Summary
- adjust Button root padding and label line-height so regular buttons measure 40px high
- add unit test for default button height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9e4a104dc83259a7f5338d49dda6e