### PR TITLE
Fix TooltipIcon layering over Drawer

### DIFF
--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -37,7 +37,7 @@ const theme = ref<TooltipIconPassThroughOptions>({
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
-    root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    root: 'absolute z-[9999] shadow-md p-fadein py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 });
 

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -7,6 +7,7 @@
 <script setup lang="ts">
 import { IconInfoCircle } from '@tabler/icons-vue';
 import { ref, computed } from 'vue';
+import { usePrimeVue } from 'primevue/config';
 import { ptMerge } from '../utils';
 
 interface TooltipDirectivePassThroughOptions {
@@ -36,6 +37,9 @@ const theme = ref<TooltipIconPassThroughOptions>({
 
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
+const primevue = usePrimeVue();
+primevue.config.zIndex.tooltip = 2147483647;
+
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
     root: {
         class: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]'
@@ -46,8 +50,6 @@ const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
 const tooltip = computed(() => ({
     value: props.text,
     appendTo: 'body',
-    autoZIndex: true,
-    baseZIndex: 20000,
     pt: ptMerge(tooltipTheme.value, props.pt?.tooltip)
 }));
 </script>

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -37,7 +37,10 @@ const theme = ref<TooltipIconPassThroughOptions>({
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
-    root: 'absolute z-[9999] shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    root: {
+        class: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        style: 'z-index: 10000 !important'
+    },
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 });
 

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -38,14 +38,16 @@ const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
     root: {
-        class: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
-        style: 'z-index: 10000 !important'
+        class: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]'
     },
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 });
 
 const tooltip = computed(() => ({
     value: props.text,
+    appendTo: 'body',
+    autoZIndex: true,
+    baseZIndex: 20000,
     pt: ptMerge(tooltipTheme.value, props.pt?.tooltip)
 }));
 </script>


### PR DESCRIPTION
## Summary
- ensure TooltipIcon tooltip uses high z-index so it isn't hidden behind Drawer overlays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9f2bcf06483259d1267e1da0fa963