### PR TITLE
feat(playground): add user detail page layout

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -93,6 +93,14 @@ const userItem = computed(() => {
   }
   return null;
 });
+
+const widthClass = computed(() =>
+  route.path.startsWith('/users/') ? 'w-full' : 'max-w-screen-2xl'
+);
+
+const containerClass = computed(() =>
+  route.path.startsWith('/users/') ? '' : 'mx-auto p-4'
+);
 </script>
 
 <template>
@@ -104,6 +112,8 @@ const userItem = computed(() => {
     :pageTabs="pageTabs"
     :linkComponent="RouterLink"
     :isSideNav="true"
+    :widthClass="widthClass"
+    :containerClass="containerClass"
   >
       <template #navLogo>
           <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -4,8 +4,10 @@ import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@ui/components/App/Index.vue';
 import RouterLink from './components/RouterLink.vue';
 import { IconHome, IconUsers, IconSettings } from '@tabler/icons-vue';
+import { Button, useModal } from '@atlas/ui';
 
 const route = useRoute();
+const { open } = useModal();
 
 const sideBarItems = computed(() => [
   {
@@ -79,6 +81,18 @@ const sideBarItems = computed(() => [
   });
 
   const pageTitle = computed(() => route.meta.title || '');
+
+const userItem = computed(() => {
+  if (route.path.startsWith('/users/') && route.params.id) {
+    const id = route.params.id;
+    return {
+      id,
+      name: `User ${id}`,
+      email: `user${id}@example.com`,
+    };
+  }
+  return null;
+});
 </script>
 
 <template>
@@ -93,6 +107,29 @@ const sideBarItems = computed(() => [
   >
       <template #navLogo>
           <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
+      </template>
+      <template v-if="userItem" #headerTitle>
+        <div class="pr-2">
+          <Button
+            as="RouterLink"
+            text
+            icon="pi pi-arrow-left"
+            size="small"
+            href="/users"
+          />
+        </div>
+        <div class="flex flex-col space-y-0 py-3">
+          <div class="text-md font-medium">{{ userItem.name }}</div>
+          <div class="text-sm text-slate-500">{{ userItem.email }}</div>
+        </div>
+      </template>
+      <template v-if="userItem" #headerAction>
+        <Button size="small" label="Edit" @click="open('ADD_EDIT_USER', userItem)" />
+      </template>
+      <template v-if="userItem" #pageSideContent>
+        <div class="h-[1000px] w-[350px] p-4">
+          <div>This is my side content</div>
+        </div>
       </template>
     <RouterView />
   </UiApp>

--- a/playground/src/pages/User.vue
+++ b/playground/src/pages/User.vue
@@ -1,11 +1,8 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
-import { App as LayoutApp, Button, useModal } from '@atlas/ui';
-import Link from '../components/RouterLink.vue';
 
 const route = useRoute();
-const { open } = useModal();
 
 const item = computed(() => ({
   id: route.params.id,
@@ -15,39 +12,8 @@ const item = computed(() => ({
 </script>
 
 <template>
-  <LayoutApp
-    :pageUrl="`/users/${item.id}`"
-    pageTitle="User"
-    :linkComponent="Link"
-  >
-    <template #headerTitle>
-      <div class="pr-2">
-        <Button
-          as="Link"
-          text
-          icon="pi pi-arrow-left"
-          size="small"
-          href="/users"
-        />
-      </div>
-      <div class="flex flex-col space-y-0 py-3">
-        <div class="text-md font-medium">{{ item.name }}</div>
-        <div class="text-sm text-slate-500">{{ item.email }}</div>
-      </div>
-    </template>
-    <template #headerAction>
-      <Button size="small" label="Edit" @click="open('ADD_EDIT_USER', item)" />
-    </template>
-    <template #pageSideContent>
-      <div class="h-[1000px] w-[350px] p-4">
-        <div>This is my side content</div>
-      </div>
-    </template>
-    <template #default>
-      <div class="h-[1000px]">
-        <div>This is my page content</div>
-        <div>{{ item }}</div>
-      </div>
-    </template>
-  </LayoutApp>
+  <div class="h-[1000px]">
+    <div>This is my page content</div>
+    <div>{{ item }}</div>
+  </div>
 </template>

--- a/playground/src/pages/User.vue
+++ b/playground/src/pages/User.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { App as LayoutApp, Button, useModal } from '@atlas/ui';
+import Link from '../components/RouterLink.vue';
+
+const route = useRoute();
+const { open } = useModal();
+
+const item = computed(() => ({
+  id: route.params.id,
+  name: `User ${route.params.id}`,
+  email: `user${route.params.id}@example.com`,
+}));
+</script>
+
+<template>
+  <LayoutApp
+    :pageUrl="`/users/${item.id}`"
+    pageTitle="User"
+    :linkComponent="Link"
+  >
+    <template #headerTitle>
+      <div class="pr-2">
+        <Button
+          as="Link"
+          text
+          icon="pi pi-arrow-left"
+          size="small"
+          href="/users"
+        />
+      </div>
+      <div class="flex flex-col space-y-0 py-3">
+        <div class="text-md font-medium">{{ item.name }}</div>
+        <div class="text-sm text-slate-500">{{ item.email }}</div>
+      </div>
+    </template>
+    <template #headerAction>
+      <Button size="small" label="Edit" @click="open('ADD_EDIT_USER', item)" />
+    </template>
+    <template #pageSideContent>
+      <div class="h-[1000px] w-[350px] p-4">
+        <div>This is my side content</div>
+      </div>
+    </template>
+    <template #default>
+      <div class="h-[1000px]">
+        <div>This is my page content</div>
+        <div>{{ item }}</div>
+      </div>
+    </template>
+  </LayoutApp>
+</template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from './pages/Home.vue';
 import Users from './pages/Users.vue';
+import User from './pages/User.vue';
 import ComponentsLayout from './pages/components/Index.vue';
 import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/forms/Index.vue';
@@ -16,6 +17,7 @@ import EditorText from './pages/components/editor/Text.vue';
 const routes = [
   { path: '/', component: Home, meta: { title: 'Dashboard' } },
   { path: '/users', component: Users, meta: { title: 'Users table' } },
+  { path: '/users/:id', component: User, meta: { title: 'User' } },
   {
     path: '/components',
     component: ComponentsLayout,


### PR DESCRIPTION
## Summary
- add User.vue page with `LayoutApp` layout
- register /users/:id route in playground router

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9fcc650d483258602307dd75485fe