### PR TITLE
Disable billing links in page side nav

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -532,6 +532,9 @@ import { DrawerForm } from '@atlas/ui';
 - `width` – optional width of drawer.
 - `errors` – form error object.
 - `tabs` – array of tab definitions.
+  - `title: string`
+  - `disabled?: boolean`
+  - `lockTooltipText?: string` – when `disabled`, display a lock icon with this tooltip.
 - `modelActiveTab` – active tab index.
 
 ##### Events

--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -83,7 +83,7 @@ import { PageSideNav } from '@atlas/ui';
 - `label: string`
 - `href: string`
 - `disabled?: boolean` – apply disabled styling and prevent navigation.
-- `lockTooltipText?: string` – when `disabled`, show a lock icon with this tooltip.
+- `lockTooltipText?: string` – when `disabled`, show a lock icon on the right with this tooltip.
 
 **Events**
 - None

--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -79,6 +79,12 @@ import { PageSideNav } from '@atlas/ui';
 - `items: NavItem[]` – navigation links. Default `[]`.
 - `linkComponent: string | object` – component used for links. Default `'a'`.
 
+**NavItem**
+- `label: string`
+- `href: string`
+- `disabled?: boolean` – apply disabled styling and prevent navigation.
+- `lockTooltipText?: string` – when `disabled`, show a lock icon with this tooltip.
+
 **Events**
 - None
 

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -45,12 +45,12 @@ const sideBarItems = computed(() => [
             { label: 'Two Factor', href: '/security/two-factor' },
           ],
         },
-        {
+        { 
           label: 'Billing',
           children: [
-            { label: 'Plans', href: '/billing/plans', disabled: true },
-            { label: 'Invoices', href: '/billing/invoices', disabled: true },
-            { label: 'Subscriptions', href: '/billing/subscriptions', disabled: true },
+            { label: 'Plans', href: '/billing/plans', disabled: true, lockTooltipText: 'Coming soon' },
+            { label: 'Invoices', href: '/billing/invoices', disabled: true, lockTooltipText: 'Coming soon' },
+            { label: 'Subscriptions', href: '/billing/subscriptions', disabled: true, lockTooltipText: 'Coming soon' },
           ],
         },
       ];

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -48,7 +48,7 @@ const sideBarItems = computed(() => [
         { 
           label: 'Billing',
           children: [
-            { label: 'Plans', href: '/billing/plans', disabled: true, lockTooltipText: 'Coming soon' },
+            { label: 'Plans', href: '/billing/plans', disabled: true },
             { label: 'Invoices', href: '/billing/invoices', disabled: true, lockTooltipText: 'Coming soon' },
             { label: 'Subscriptions', href: '/billing/subscriptions', disabled: true, lockTooltipText: 'Coming soon' },
           ],

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -48,9 +48,9 @@ const sideBarItems = computed(() => [
         {
           label: 'Billing',
           children: [
-            { label: 'Plans', href: '/billing/plans' },
-            { label: 'Invoices', href: '/billing/invoices' },
-            { label: 'Subscriptions', href: '/billing/subscriptions' },
+            { label: 'Plans', href: '/billing/plans', disabled: true },
+            { label: 'Invoices', href: '/billing/invoices', disabled: true },
+            { label: 'Subscriptions', href: '/billing/subscriptions', disabled: true },
           ],
         },
       ];

--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -61,7 +61,7 @@ const submitDrawerForm = () => {
         <DrawerForm
           v-model="drawerFormVisible"
           :title="form.id ? 'Edit user' : 'Add user'"
-          :tabs="[{ title: 'Details' }, { title: 'Line items' }, { title: 'Roles', disabled: true }]"
+          :tabs="[{ title: 'Details' }, { title: 'Line items' }, { title: 'Roles', disabled: true, lockTooltipText: 'Manage roles in settings' }]"
           position="right"
           width="600px"
           :loading="form.processing"

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -23,15 +23,15 @@
                                         child.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                                     ]"
                                 >
-                                    <span class="flex items-center gap-2">
+                                    <span class="flex items-center">
+                                        <span class="flex-1">{{ child.label }}</span>
                                         <span
                                             v-if="child.disabled && child.lockTooltipText"
-                                            v-tooltip.top="{ value: child.lockTooltipText, pt: tooltipPt }"
-                                            class="pointer-events-auto"
+                                            v-tooltip.right="{ value: child.lockTooltipText, pt: tooltipPt }"
+                                            class="ml-auto pl-2 pointer-events-auto"
                                         >
                                             <IconLock size="16" />
                                         </span>
-                                        <span>{{ child.label }}</span>
                                     </span>
                                 </component>
                             </li>
@@ -49,15 +49,15 @@
                             item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                         ]"
                     >
-                        <span class="flex items-center gap-2">
+                        <span class="flex items-center">
+                            <span class="flex-1">{{ item.label }}</span>
                             <span
                                 v-if="item.disabled && item.lockTooltipText"
-                                v-tooltip.top="{ value: item.lockTooltipText, pt: tooltipPt }"
-                                class="pointer-events-auto"
+                                v-tooltip.right="{ value: item.lockTooltipText, pt: tooltipPt }"
+                                class="ml-auto pl-2 pointer-events-auto"
                             >
                                 <IconLock size="16" />
                             </span>
-                            <span>{{ item.label }}</span>
                         </span>
                     </component>
                 </template>
@@ -93,7 +93,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { items, linkComponent } = props;
 
 const tooltipPt = {
-    root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    root: 'absolute ml-2 shadow-md p-fadein py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 };
 

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -19,7 +19,8 @@
                                     :class="[
                                         isActive(child)
                                             ? 'bg-surface-100 dark:bg-surface-700 text-primary-800 dark:text-white font-semibold'
-                                            : 'text-slate-900 hover:bg-surface-100 dark:text-slate-300 dark:hover:bg-surface-700'
+                                            : 'text-slate-900 hover:bg-surface-100 dark:text-slate-300 dark:hover:bg-surface-700',
+                                        child.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                                     ]"
                                 >
                                     {{ child.label }}
@@ -35,7 +36,8 @@
                         :class="[
                             isActive(item)
                                 ? 'bg-surface-100 dark:bg-surface-700 text-primary-800 dark:text-white font-semibold'
-                                : 'text-slate-900 hover:bg-surface-100 dark:text-slate-300 dark:hover:bg-surface-700'
+                                : 'text-slate-900 hover:bg-surface-100 dark:text-slate-300 dark:hover:bg-surface-700',
+                            item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                         ]"
                     >
                         {{ item.label }}
@@ -55,6 +57,7 @@ interface NavItem {
     href: string;
     parent?: string;
     children?: NavItem[];
+    disabled?: boolean;
 }
 
 interface Props {

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -23,7 +23,16 @@
                                         child.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                                     ]"
                                 >
-                                    {{ child.label }}
+                                    <span class="flex items-center gap-2">
+                                        <span
+                                            v-if="child.disabled && child.lockTooltipText"
+                                            v-tooltip.top="{ value: child.lockTooltipText, pt: tooltipPt }"
+                                            class="pointer-events-auto"
+                                        >
+                                            <IconLock size="16" />
+                                        </span>
+                                        <span>{{ child.label }}</span>
+                                    </span>
                                 </component>
                             </li>
                         </ul>
@@ -40,7 +49,16 @@
                             item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
                         ]"
                     >
-                        {{ item.label }}
+                        <span class="flex items-center gap-2">
+                            <span
+                                v-if="item.disabled && item.lockTooltipText"
+                                v-tooltip.top="{ value: item.lockTooltipText, pt: tooltipPt }"
+                                class="pointer-events-auto"
+                            >
+                                <IconLock size="16" />
+                            </span>
+                            <span>{{ item.label }}</span>
+                        </span>
                     </component>
                 </template>
             </div>
@@ -50,6 +68,7 @@
 
 <script setup lang="ts">
 import ScrollFrame from '../../ScrollFrame.vue';
+import { IconLock } from '@tabler/icons-vue';
 import { isPageActive } from '../../../utils';
 
 interface NavItem {
@@ -58,6 +77,7 @@ interface NavItem {
     parent?: string;
     children?: NavItem[];
     disabled?: boolean;
+    lockTooltipText?: string;
 }
 
 interface Props {
@@ -71,6 +91,11 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const { items, linkComponent } = props;
+
+const tooltipPt = {
+    root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+};
 
 const isActive = (item: NavItem) =>
     item.parent ? isPageActive(item.parent) : isPageActive(item.href, undefined, true);

--- a/ui/src/components/DrawerForm.vue
+++ b/ui/src/components/DrawerForm.vue
@@ -32,8 +32,16 @@
                                     ]"
                                     @click="() => { if (!tab?.disabled) activeTab = i }"
                                 >
-                                    <IconLock v-if="tab?.disabled" size="16" />
-                                    <span>{{ tab.title }}</span>
+                                    <span class="flex items-center gap-1">
+                                        <span
+                                            v-if="tab?.disabled && tab.lockTooltipText"
+                                            v-tooltip.top="{ value: tab.lockTooltipText, pt: tooltipPt }"
+                                            class="pointer-events-auto"
+                                        >
+                                            <IconLock size="16" />
+                                        </span>
+                                        <span>{{ tab.title }}</span>
+                                    </span>
                                 </button>
                             </li>
                         </ul>
@@ -73,7 +81,7 @@ import Button from './Button.vue';
 import { IconLock } from '@tabler/icons-vue';
 import { ref, watch } from 'vue';
 
-type Tab = { title: string; disabled?: boolean };
+type Tab = { title: string; disabled?: boolean; lockTooltipText?: string };
 
 const props = defineProps({
     modelValue: Boolean,
@@ -93,6 +101,11 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'submit', 'update:modelActiveTab']);
 const activeTab = ref(props.modelActiveTab);
+
+const tooltipPt = {
+    root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+};
 
 watch(activeTab, val => emit('update:modelActiveTab', val));
 watch(() => props.modelActiveTab, val => activeTab.value = val);

--- a/ui/tests/components/SideNav.test.ts
+++ b/ui/tests/components/SideNav.test.ts
@@ -22,6 +22,7 @@ describe('PageSideNav', () => {
         const link = wrapper.find('a');
         expect(link.classes()).toContain('opacity-50');
         expect(link.classes()).toContain('cursor-not-allowed');
+        expect(wrapper.findComponent(IconLock).exists()).toBe(false);
     });
 
     it('shows lock icon when lockTooltipText provided', () => {

--- a/ui/tests/components/SideNav.test.ts
+++ b/ui/tests/components/SideNav.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PageSideNav from '../../src/components/App/Page/SideNav.vue';
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ url: '/' })
+}));
+
+describe('PageSideNav', () => {
+    it('renders disabled items', () => {
+        const wrapper = mount(PageSideNav, {
+            props: {
+                items: [
+                    { label: 'Billing', href: '/billing', disabled: true }
+                ]
+            }
+        });
+        const link = wrapper.find('a');
+        expect(link.classes()).toContain('opacity-50');
+        expect(link.classes()).toContain('cursor-not-allowed');
+    });
+});

--- a/ui/tests/components/SideNav.test.ts
+++ b/ui/tests/components/SideNav.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PageSideNav from '../../src/components/App/Page/SideNav.vue';
+import { IconLock } from '@tabler/icons-vue';
 
 vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({ url: '/' })
@@ -13,10 +14,27 @@ describe('PageSideNav', () => {
                 items: [
                     { label: 'Billing', href: '/billing', disabled: true }
                 ]
+            },
+            global: {
+                directives: { tooltip: vi.fn() }
             }
         });
         const link = wrapper.find('a');
         expect(link.classes()).toContain('opacity-50');
         expect(link.classes()).toContain('cursor-not-allowed');
+    });
+
+    it('shows lock icon when lockTooltipText provided', () => {
+        const wrapper = mount(PageSideNav, {
+            props: {
+                items: [
+                    { label: 'Billing', href: '/billing', disabled: true, lockTooltipText: 'Locked' }
+                ]
+            },
+            global: {
+                directives: { tooltip: vi.fn() }
+            }
+        });
+        expect(wrapper.findComponent(IconLock).exists()).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- support disabled items in `PageSideNav`
- mark Billing pages as disabled in playground example
- add unit test covering disabled side nav items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9feb6f08083258d73aaa5d57ebc6d