### PR TITLE
docs: add missing UI component documentation

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -36,12 +36,18 @@ Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
     - [Card](#card)
     - [Divider](#divider)
     - [Dialog](#dialog)
+    - [DialogConfirmation](#dialogconfirmation)
     - [Drawer](#drawer)
     - [DrawerForm](#drawerform)
+    - [Topbar](#topbar)
     - [Popover](#popover)
     - [Tabs](#tabs)
   - [Data Display](#data-display)
     - [DataTable](#datatable)
+    - [Table](#table)
+    - [TableActions](#tableactions)
+    - [TableCustomizeColumns](#tablecustomizecolumns)
+    - [EditorContent](#editorcontent)
     - [Avatar](#avatar)
     - [AvatarGroup](#avatargroup)
     - [Chip](#chip)
@@ -498,6 +504,29 @@ import { Dialog, Button } from '@atlas/ui';
 
 Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).
 
+#### DialogConfirmation
+```ts
+import { DialogConfirmation } from '@atlas/ui';
+```
+
+```vue
+<DialogConfirmation v-model="open" title="Delete item" @confirm="remove" />
+```
+
+##### Props
+
+- `modelValue: boolean` – controls visibility.
+- `title: string` – header text. Default `'Delete Item'`.
+- `icon: string` – icon class for the dialog. Default `'pi pi-trash'`.
+- `message: string` – confirmation message.
+- `loading: boolean` – disable buttons and show loading state.
+- `pt: object` – passthrough options for internal elements.
+
+##### Events
+
+- `update:modelValue` – emitted when visibility changes.
+- `confirm` – emitted when the confirm button is clicked.
+
 #### Drawer
 ```ts
 import { Drawer } from '@atlas/ui';
@@ -542,6 +571,29 @@ import { DrawerForm } from '@atlas/ui';
 - `update:modelValue` – emitted when visibility changes.
 - `submit` – emitted on save.
 - `update:modelActiveTab` – emitted when active tab changes.
+
+#### Topbar
+```ts
+import { Topbar } from '@atlas/ui';
+```
+
+```vue
+<Topbar>
+  <span>Announcements</span>
+</Topbar>
+```
+
+##### Props
+
+- `pt: object` – passthrough options for internal elements.
+
+##### Slots
+
+- `default` – content rendered inside the bar.
+
+##### Events
+
+- None
 
 #### Popover
 ```ts
@@ -693,6 +745,116 @@ import { TooltipInfo } from '@atlas/ui';
 ##### Slots
 
 - `default` – content displayed inside the popover.
+
+#### Table
+```ts
+import { Table } from '@atlas/ui';
+```
+
+```vue
+<Table
+  :items="rows"
+  :columns="columns"
+  :activeColumnList="activeColumns"
+  @sort="onSort"
+/>
+```
+
+##### Props
+
+- `items: any[]` – table data rows.
+- `itemTotal: number` – total item count.
+- `selected: any[]` – selected rows.
+- `selectAll: boolean` – select all across pages.
+- `columns: any[]` – column definitions.
+- `activeColumnList: any[]` – ordered list of visible column keys.
+- `defaultColumnList: any[]` – default column keys.
+- `size: string` – table size, default `'small'`.
+- `tableStyle: string` – inline style for table width.
+- `dataKey: string` – unique key field, default `'id'`.
+- `emptyLabel: string` – message when no data, default `'No results'`.
+- `hasSelectAll: boolean` – show select-all menu.
+- `hasSelection: boolean` – enable row selection.
+- `hasCustomizeColumns: boolean` – enable column customization UI.
+- `scrollOffset: number` – additional offset for the scroll frame.
+- `scrollable: boolean` – enable DataTable scrolling.
+
+##### Events
+
+- `sort` – emitted with `{ field, order }` when sorting changes.
+- `update:selected` – emitted with selected rows.
+- `update:selectAll` – emitted when the select-all state changes.
+- `update:activeColumnList` – emitted with new active column keys.
+
+##### Slots
+
+- `columnKey` – named slots for custom cell templates using the column key.
+- `empty` – content shown when no rows exist.
+
+Built on PrimeVue's DataTable. See the [DataTable API](https://primevue.org/datatable/#api) for additional options.
+
+#### TableActions
+```ts
+import { TableActions } from '@atlas/ui';
+```
+
+```vue
+<TableActions :selectedCount="selected.length" :menuItems="actions" @action="onAction" />
+```
+
+##### Props
+
+- `selectedCount: number` – number of selected rows.
+- `menuItems: any[]` – action definitions. Child items may provide nested menus.
+
+##### Events
+
+- `action` – emitted with the action identifier. `'clear'` is emitted when the clear button is pressed.
+
+#### TableCustomizeColumns
+```ts
+import { TableCustomizeColumns } from '@atlas/ui';
+```
+
+```vue
+<TableCustomizeColumns
+  :columns="columns"
+  :activeColumnList="active"
+  :defaultColumnList="defaults"
+  @update="val => active = val"
+>
+  <template #trigger="{ toggle }">
+    <button @click="toggle">Columns</button>
+  </template>
+</TableCustomizeColumns>
+```
+
+##### Props
+
+- `columns: any[]` – column definitions.
+- `activeColumnList: any[]` – visible column keys.
+- `defaultColumnList: any[]` – default visible column keys.
+
+##### Events
+
+- `update` – emitted with new array of active column keys.
+
+##### Slots
+
+- `trigger` – custom element that toggles the popover.
+
+#### EditorContent
+```ts
+import { EditorContent } from '@atlas/ui';
+```
+
+```vue
+<EditorContent :content="html" />
+```
+
+##### Props
+
+- `content: string` – HTML string to render.
 
 ### Navigation
 

--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -10,6 +10,7 @@ For an all-in-one page wrapper that composes these pieces together, see the [App
   - [NavSidebar](#navsidebar)
   - [PageSideNav](#pagesidenav)
 - [Layout](#layout)
+  - [Topbar](#topbar)
   - [PageHeader](#pageheader)
   - [PageContent](#pagecontent)
   - [PageFooter](#pagefooter)
@@ -90,6 +91,28 @@ import { PageSideNav } from '@atlas/ui';
 
 ## Layout
 Structural components that organize page content and actions.
+
+### Topbar
+Simple bar displayed above page content.
+
+```ts
+import { Topbar } from '@atlas/ui';
+```
+
+```vue
+<Topbar>
+  <span>Announcements</span>
+</Topbar>
+```
+
+**Props**
+- `pt?: object` – passthrough options for internal elements.
+
+**Slots**
+- `default` – bar content.
+
+**Events**
+- None
 
 ### PageHeader
 Page-level header with optional breadcrumbs and tabs.

--- a/docs/ui/editor.md
+++ b/docs/ui/editor.md
@@ -42,3 +42,13 @@ import { Editor } from '@atlas/ui';
 ```
 Bind `v-model` to your data to read and write HTML content.
 
+## Displaying Content
+```ts
+import { EditorContent } from '@atlas/ui';
+```
+
+```vue
+<EditorContent :content="html" />
+```
+Use `EditorContent` to render editor output as HTML.
+

--- a/docs/ui/table.md
+++ b/docs/ui/table.md
@@ -7,6 +7,9 @@ Atlas DataTable component extends PrimeVue's DataTable with Atlas styling and ut
 - [Columns](#columns)
 - [Pagination and Sorting](#pagination-and-sorting)
 - [CSV Export](#csv-export)
+- [Application Table](#application-table)
+- [Table Actions](#table-actions)
+- [Customize Columns](#customize-columns)
 
 ## Basic Usage
 ```ts
@@ -40,3 +43,98 @@ Call the `exportCSV` method on the component reference to download data.
 ```
 
 Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api) for all available options.
+
+## Application Table
+The `Table` component builds on `DataTable` to add selection and column management utilities.
+
+```ts
+import { Table } from '@atlas/ui';
+```
+
+```vue
+<Table
+  :items="rows"
+  :columns="columns"
+  :activeColumnList="active"
+  @sort="onSort"
+/> 
+```
+
+### Props
+- `items: any[]` – table rows.
+- `itemTotal: number` – total item count.
+- `selected: any[]` – selected rows.
+- `selectAll: boolean` – select all rows across pages.
+- `columns: any[]` – column definitions.
+- `activeColumnList: any[]` – ordered list of visible column keys.
+- `defaultColumnList: any[]` – default column keys.
+- `size: string` – table size; default `'small'`.
+- `tableStyle: string` – inline style for table width.
+- `dataKey: string` – unique key field; default `'id'`.
+- `emptyLabel: string` – message when no data; default `'No results'`.
+- `hasSelectAll: boolean` – show select-all menu.
+- `hasSelection: boolean` – enable row selection.
+- `hasCustomizeColumns: boolean` – enable column customization UI.
+- `scrollOffset: number` – additional offset for the scroll frame.
+- `scrollable: boolean` – enable DataTable scrolling.
+
+### Events
+- `sort` – emitted with `{ field, order }` when sorting changes.
+- `update:selected` – emitted with selected rows.
+- `update:selectAll` – emitted when the select-all state changes.
+- `update:activeColumnList` – emitted with new active column keys.
+
+### Slots
+- `columnKey` – named slots for custom cell templates using the column key.
+- `empty` – content shown when no results.
+
+Built on PrimeVue's DataTable. See the [DataTable API](https://primevue.org/datatable/#api) for additional options.
+
+## Table Actions
+`TableActions` displays the number of selected rows and contextual actions.
+
+```ts
+import { TableActions } from '@atlas/ui';
+```
+
+```vue
+<TableActions :selectedCount="selected.length" :menuItems="actions" @action="onAction" />
+```
+
+### Props
+- `selectedCount: number` – number of selected rows.
+- `menuItems: any[]` – action definitions.
+
+### Events
+- `action` – emitted with the action identifier. `'clear'` is emitted when the clear button is pressed.
+
+## Customize Columns
+`TableCustomizeColumns` renders a popover to toggle and reorder columns.
+
+```ts
+import { TableCustomizeColumns } from '@atlas/ui';
+```
+
+```vue
+<TableCustomizeColumns
+  :columns="columns"
+  :activeColumnList="active"
+  :defaultColumnList="defaults"
+  @update="val => active = val"
+>
+  <template #trigger="{ toggle }">
+    <button @click="toggle">Columns</button>
+  </template>
+</TableCustomizeColumns>
+```
+
+### Props
+- `columns: any[]` – full column definitions.
+- `activeColumnList: any[]` – visible column keys.
+- `defaultColumnList: any[]` – default column keys.
+
+### Events
+- `update` – emitted with new array of active column keys.
+
+### Slots
+- `trigger` – element that toggles the popover.


### PR DESCRIPTION
## Summary
- document dialog confirmation modal
- cover Topbar layout component
- expand table docs and add editor content renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa056fd9c08325a34098b6e671c438