### PR TITLE
fix: recalc ScrollFrame height after SPA page change

### DIFF
--- a/ui/src/components/ScrollFrame.vue
+++ b/ui/src/components/ScrollFrame.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import { ref, watch, nextTick, onMounted, onBeforeUnmount, onUpdated } from 'vue';
 import { useScroll } from '../composables/useScroll';
 
 interface Props {
@@ -67,6 +67,12 @@ onMounted(() => {
             resizeObserver.observe(document.body);
         }
     }
+});
+
+onUpdated(() => {
+    nextTick(() => {
+        updateHeight();
+    });
 });
 
 onBeforeUnmount(() => {

--- a/ui/tests/components/ScrollFrame.test.ts
+++ b/ui/tests/components/ScrollFrame.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick, ref } from 'vue';
+import ScrollFrame from '../../src/components/ScrollFrame.vue';
+
+describe('ScrollFrame', () => {
+    it('recalculates height when content updates', async () => {
+        let top = 10;
+        const getBoundingClientRect = vi.spyOn(
+            HTMLElement.prototype,
+            'getBoundingClientRect'
+        );
+        getBoundingClientRect.mockImplementation(() => ({
+            top,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: 0,
+            x: 0,
+            y: top,
+            toJSON: () => {}
+        }));
+
+        const Parent = {
+            components: { ScrollFrame },
+            setup() {
+                const content = ref('A');
+                return { content };
+            },
+            template: `<ScrollFrame><div>{{ content }}</div></ScrollFrame>`
+        };
+
+        const wrapper = mount(Parent);
+        const frameComp = wrapper.findComponent(ScrollFrame);
+
+        await nextTick();
+        expect(frameComp.vm.dynamicHeight).toBe('10px');
+
+        top = 20;
+        (wrapper.vm as any).content = 'B';
+
+        await nextTick();
+        await nextTick();
+
+        expect(frameComp.vm.dynamicHeight).toBe('20px');
+
+        getBoundingClientRect.mockRestore();
+    });
+});
+


### PR DESCRIPTION
## Summary
- recompute ScrollFrame height on content updates to avoid incorrect scroll after SPA navigation
- add unit test for ScrollFrame dynamic height recalculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa13c704288325949fb435513fd156