### PR TITLE
Improve user pages with mock data and layout slots

### DIFF
--- a/playground/src/components/LinkPaginator.vue
+++ b/playground/src/components/LinkPaginator.vue
@@ -1,0 +1,18 @@
+<script setup>
+const props = defineProps({
+  links: {
+    type: Array,
+    default: () => [],
+  },
+  linkComponent: {
+    type: String,
+    default: 'a',
+  },
+});
+</script>
+
+<template>
+  <div class="flex items-center justify-center py-2">
+    <span class="text-sm text-slate-500">Pagination placeholder</span>
+  </div>
+</template>

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -2,7 +2,7 @@
 import { useRoute } from 'vue-router';
 import LayoutApp from '@ui/components/App/Index.vue';
 import { Button, useModal } from '@atlas/ui';
-import RouterLink from '../components/RouterLink.vue';
+import Link from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 
 const props = defineProps({
@@ -22,13 +22,13 @@ const route = useRoute();
         :pageUrl="route.fullPath"
         :pageTitle="'User'"
         :sideBarItems="sideBarItems"
-        :linkComponent="RouterLink"
+        :linkComponent="Link"
         :isSideNav="true"
     >
         <template #headerTitle>
             <div class="pr-2">
                 <Button
-                    as="RouterLink"
+                    as="Link"
                     text
                     icon="pi pi-arrow-left"
                     size="small"

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -1,44 +1,53 @@
 <script setup>
 import { ref, computed } from 'vue';
+import LayoutApp from '@ui/components/App/Index.vue';
 import { Table, ButtonMenu, TableActions, InputText, Button, Select, useModal } from '@atlas/ui';
 import Link from '../components/RouterLink.vue';
+import LinkPaginator from '../components/LinkPaginator.vue';
+import { sideBarItems } from '../sideBarItems';
 
 const { open } = useModal();
 
 const tableActionMenuItems = ref([
-  { label: 'Edit', action: 'edit' },
-  { label: 'Delete', action: 'delete', disabled: true, tooltip: 'This action is disabled.' },
-  {
-    label: 'More',
-    children: [
-      { label: 'Export', action: 'export' },
-      { separator: true },
-      { label: 'Duplicate', action: 'dup', disabled: true },
-      { label: 'Email', action: 'email', disabled: true },
-    ],
-  },
+    { label: 'Edit', action: 'edit' },
+    { label: 'Delete', action: 'delete', disabled: true, tooltip: 'This action is disabled.'},
+    { label: 'More',
+        children:
+        [
+            { label: 'Export', action: 'export' },
+            { separator: true },
+            { label: 'Duplicate', action: 'dup', disabled: true, },
+            { label: 'Email', action: 'email', disabled: true },
+        ]
+    }
 ]);
 
 const handleTableAction = (action) => {
-  if (action === 'clear') {
-    resetSelection();
-  }
+    if (action === 'clear') {
+        resetSelection();
+    }
 };
 
 const columns = [
-  { key: 'edit', header: '', class: 'w-[20px]', sortable: false, frozen: true, style: 'min-width: 40px', locked: true, hidden: true },
-  { key: 'name', header: 'Name', sortable: true, frozen: true, style: 'min-width: 200px', locked: true },
-  { key: 'email', header: 'Email', sortable: true, style: 'min-width: 200px' },
-  { key: 'email2', header: 'Email 2', sortable: true, style: 'min-width: 200px' },
-  { key: 'email3', header: 'Email 3', sortable: true, style: 'min-width: 200px' },
-  { key: 'email4', header: 'Email 4', sortable: true, style: 'min-width: 200px' },
+    { key: 'edit', header: '', class: 'w-[20px]', sortable: false, frozen: true, style: 'min-width: 40px', locked: true, hidden: true },
+    { key: 'name', header: 'Name', sortable: true, frozen: true, style: 'min-width: 200px', locked: true },
+    { key: 'email', header: 'Email', sortable: true, style: 'min-width: 200px' },
+    { key: 'email2', header: 'Email 2', sortable: true, style: 'min-width: 200px' },
+    { key: 'email3', header: 'Email 3', sortable: true, style: 'min-width: 400px;' },
+    { key: 'email4', header: 'Email 3', sortable: true, style: 'min-width: 200px;' },
+    { key: 'email5', header: 'Email 3', sortable: true, style: 'min-width: 200px;' },
+    { key: 'email6', header: 'Email 3', sortable: true, style: 'min-width: 200px;', group: 'Email fields' },
+    { key: 'email7', header: 'Email 3', sortable: true, style: 'min-width: 200px;', group: 'Email fields' },
+    { key: 'email8', header: 'Email 3', sortable: true, style: 'min-width: 200px;', group: 'Email fields' },
+    { key: 'email9', header: 'Email 3', sortable: true, style: 'min-width: 200px;', group: 'Email fields' },
+    { key: 'email0', header: 'Email 3', sortable: true, style: 'min-width: 200px;', group: 'Email fields' },
 ];
 
 const perPageOptions = [
-  { label: '15', value: 15 },
-  { label: '25', value: 25 },
-  { label: '50', value: 50 },
-  { label: '100', value: 100 },
+    { label: '15', value: 15 },
+    { label: '25', value: 25 },
+    { label: '50', value: 50 },
+    { label: '100', value: 100 },
 ];
 
 const search = ref('');
@@ -52,116 +61,141 @@ const selected = ref([]);
 const defaultColumnList = ['edit', 'name', 'email'];
 
 const resetSelection = () => {
-  selectAll.value = false;
-  selected.value = [];
+    selectAll.value = false;
+    selected.value = [];
 };
 
 const onSort = ({ field, order }) => {
-  sortField.value = field;
-  sortOrder.value = order;
+    sortField.value = field;
+    sortOrder.value = order;
 };
 
 const mockUsers = Array.from({ length: 100 }, (_, i) => ({
-  id: i + 1,
-  name: `User ${i + 1}`,
-  email: `user${i + 1}@example.com`,
-  email2: `user${i + 1}.2@example.com`,
-  email3: `user${i + 1}.3@example.com`,
-  email4: `user${i + 1}.4@example.com`,
+    id: i + 1,
+    name: `User ${i + 1}`,
+    email: `user${i + 1}@example.com`,
+    email2: `user${i + 1}.2@example.com`,
+    email3: `user${i + 1}.3@example.com`,
+    email4: `user${i + 1}.4@example.com`,
+    email5: `user${i + 1}.5@example.com`,
+    email6: `user${i + 1}.6@example.com`,
+    email7: `user${i + 1}.7@example.com`,
+    email8: `user${i + 1}.8@example.com`,
+    email9: `user${i + 1}.9@example.com`,
+    email0: `user${i + 1}.0@example.com`,
 }));
 
 const filteredUsers = computed(() =>
-  mockUsers.filter(
-    (u) =>
-      u.name.toLowerCase().includes(search.value.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.value.toLowerCase())
-  )
+    mockUsers.filter(
+        (u) =>
+            u.name.toLowerCase().includes(search.value.toLowerCase()) ||
+            u.email.toLowerCase().includes(search.value.toLowerCase())
+    )
 );
 
 const sortedUsers = computed(() =>
-  [...filteredUsers.value].sort((a, b) => {
-    const field = sortField.value;
-    const order = sortOrder.value;
-    if (a[field] < b[field]) return -1 * order;
-    if (a[field] > b[field]) return 1 * order;
-    return 0;
-  })
+    [...filteredUsers.value].sort((a, b) => {
+        const field = sortField.value;
+        const order = sortOrder.value;
+        if (a[field] < b[field]) return -1 * order;
+        if (a[field] > b[field]) return 1 * order;
+        return 0;
+    })
 );
 
 const paginatedUsers = computed(() => sortedUsers.value.slice(0, perPage.value));
 
-const userTotal = computed(() => filteredUsers.value.length);
+const users = computed(() => ({
+    data: paginatedUsers.value,
+    total: filteredUsers.value.length,
+    links: [],
+}));
+
+const userTotal = computed(() => users.value.total);
 </script>
 
 <template>
-  <section class="flex flex-col h-full overflow-hidden">
-    <div class="flex items-center justify-between">
-      <div>
-        <TableActions
-          v-if="(selectAll ? userTotal : selected.length) > 0"
-          :selectedCount="selectAll ? userTotal : selected.length"
-          :menuItems="tableActionMenuItems"
-          @action="handleTableAction"
-        />
-      </div>
-      <div class="flex items-center space-x-2">
-        <InputText
-          v-model="search"
-          placeholder="Search user name or email"
-          class="w-[400px]"
-          size="small"
-          clearable
-        />
-        <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
-      </div>
-    </div>
-    <div class="flex-1 overflow-hidden bg-white dark:bg-surface-800">
-      <Table
-        :items="paginatedUsers"
-        :itemTotal="userTotal"
-        :columns="columns"
-        :sortField="sortField"
-        :sortOrder="sortOrder"
-        :selected="selected"
-        :selectAll="selectAll"
-        :defaultColumnList="defaultColumnList"
-        :activeColumnList="viewFields"
-        hasSelection
-        hasCustomizeColumns
-        :scrollOffset="53"
-        scrollable
-        @update:selected="selected = $event"
-        @update:selectAll="selectAll = $event"
-        @update:activeColumnList="viewFields = $event"
-        @sort="onSort"
-      >
-        <template #edit="{ data }">
-          <div class="w-full flex items-center justify-center">
-            <ButtonMenu
-              :items="[
-                { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
-                { separator: true },
-                { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
-              ]"
+    <LayoutApp
+        title="Users"
+        :pageTitle="`Users (${userTotal})`"
+        containerClass="p-0"
+        :noScroll="true"
+        :sideBarItems="sideBarItems"
+        :linkComponent="Link"
+        :isSideNav="true"
+    >
+        <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
+            <TableActions
+                :selectedCount="selectAll ? userTotal : selected?.length"
+                :menuItems="tableActionMenuItems"
+                @action="handleTableAction"
             />
-          </div>
         </template>
-        <template #name="{ data }">
-          <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
-            {{ data.name }}
-          </Link>
+        <template #headerAction>
+            <div class="flex items-center justify-between">
+                <div class="flex items-center space-x-2">
+                    <InputText
+                        v-model="search"
+                        placeholder="Search user name or email"
+                        class="w-[400px]"
+                        size="small"
+                        clearable
+                    />
+                    <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
+                </div>
+            </div>
         </template>
-      </Table>
-    </div>
-    <div>
-      <Select
-        v-model="perPage"
-        :options="perPageOptions"
-        size="small"
-        option-label="label"
-        option-value="value"
-      />
-    </div>
-  </section>
+        <template #default>
+            <div class="bg-white dark:bg-surface-800">
+                <Table
+                    :items="users.data"
+                    :itemTotal="userTotal"
+                    :columns="columns"
+                    :sortField="sortField"
+                    :sortOrder="sortOrder"
+                    :selected="selected"
+                    :selectAll="selectAll"
+                    :defaultColumnList="defaultColumnList"
+                    :activeColumnList="viewFields"
+                    hasSelection
+                    hasCustomizeColumns
+                    :scrollOffset="53"
+                    scrollable
+                    @update:selected="selected = $event"
+                    @update:selectAll="selectAll = $event"
+                    @update:activeColumnList="viewFields = $event"
+                    @sort="onSort"
+                >
+                    <template #edit="{ data }">
+                        <div class="w-full flex items-center justify-center">
+                            <ButtonMenu
+                                :items="[
+                                    { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
+                                    { separator: true },
+                                    { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
+                                ]"
+                            />
+                        </div>
+                    </template>
+                    <template #name="{ data }">
+                        <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
+                            {{ data.name }}
+                        </Link>
+                    </template>
+                </Table>
+            </div>
+        </template>
+        <template #footer>
+            <Select
+                v-model="perPage"
+                :options="perPageOptions"
+                size="small"
+                option-label="label"
+                option-value="value"
+            />
+        </template>
+        <template #footerAction>
+            <LinkPaginator :links="users.links" :linkComponent="'Link'" />
+        </template>
+    </LayoutApp>
 </template>
-

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -12,7 +12,6 @@ import Editor from './pages/components/editor/Index.vue';
 import EditorVariant from './pages/components/editor/Variant.vue';
 import EditorText from './pages/components/editor/Text.vue';
 import MainLayout from './layouts/MainLayout.vue';
-import UsersLayout from './layouts/UsersLayout.vue';
 import UserLayout from './layouts/UserLayout.vue';
 import ComponentsLayout from './layouts/ComponentsLayout.vue';
 
@@ -26,15 +25,20 @@ const routes = [
   },
   {
     path: '/users',
-    component: UsersLayout,
-    children: [
-      { path: '', component: Users, meta: { title: 'Users table' } },
-    ],
+    component: Users,
+    meta: { title: 'Users table' },
   },
   {
     path: '/users/:id',
     component: UserLayout,
     meta: { title: 'User details' },
+    props: route => ({
+      item: {
+        id: Number(route.params.id),
+        name: `User ${route.params.id}`,
+        email: `user${route.params.id}@example.com`,
+      },
+    }),
   },
   {
     path: '/components',


### PR DESCRIPTION
## Summary
- Pass mock user data into user detail layout and add header title
- Rebuild users table page with LayoutApp and edge-to-edge table
- Add placeholder LinkPaginator component for footer actions

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68aa1360515883259b127e328bf189e0