### PR TITLE
fix hover menu closing when moving to menu

### DIFF
--- a/ui/src/components/ButtonMenu.vue
+++ b/ui/src/components/ButtonMenu.vue
@@ -119,11 +119,13 @@ const onTriggerEnter = async () => {
     if (el) menu.value.show({ currentTarget: el });
 };
 
-const onTriggerLeave = () => {
+const onTriggerLeave = (e: MouseEvent) => {
     if (!props.onHover) return;
+    const toEl = e.relatedTarget as Node | null;
+    if (menu.value?.$el?.contains(toEl)) return;
     closeTimeout.value = setTimeout(() => {
         if (isMenuOpen.value) menu.value.hide();
-    }, 100);
+    }, 200);
 };
 
 const toggleMenu = () => {
@@ -134,11 +136,14 @@ const toggleMenu = () => {
 const onMenuShow = () => (isMenuOpen.value = true);
 const onMenuHide = () => (isMenuOpen.value = false);
 const onMenuEnter = () => clearTimeout(closeTimeout.value);
-const onMenuLeave = () => {
+const onMenuLeave = (e: MouseEvent) => {
     if (!props.onHover) return;
+    const toEl = e.relatedTarget as Node | null;
+    const triggerEl = getTriggerEl();
+    if (triggerEl?.contains(toEl)) return;
     closeTimeout.value = setTimeout(() => {
         if (isMenuOpen.value) menu.value.hide();
-    }, 100);
+    }, 200);
 };
 
 const actionClick = (item: any) => {


### PR DESCRIPTION
## Summary
- prevent ButtonMenu hover menu from closing when moving between trigger and menu by checking `relatedTarget` and adding a delay

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa18b0abe48325add93b2337609eb9