### PR TITLE
Add mock user modals and refine ButtonMenu behavior

### DIFF
--- a/playground/src/components/UserModals.vue
+++ b/playground/src/components/UserModals.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { reactive, watch } from 'vue';
+import { DrawerForm, DialogConfirmation, LabelField, InputText, useModal } from '@atlas/ui';
+
+const { activeState, data, close } = useModal();
+
+const addEditUserVisible = activeState('ADD_EDIT_USER');
+const deleteUserVisible = activeState('DELETE_USER');
+const addEditUserData = data('ADD_EDIT_USER');
+const deleteUserData = data('DELETE_USER');
+
+const form = reactive({
+  id: null as number | null,
+  name: '',
+  email: '',
+  processing: false,
+  errors: {} as Record<string, any>,
+});
+
+watch(addEditUserVisible, (visible) => {
+  if (visible) {
+    const user: any = addEditUserData.value || {};
+    form.id = user.id ?? null;
+    form.name = user.name ?? '';
+    form.email = user.email ?? '';
+    form.errors = {};
+  }
+});
+
+const submit = () => {
+  close('ADD_EDIT_USER');
+};
+
+const confirmDelete = () => {
+  close('DELETE_USER');
+};
+</script>
+
+<template>
+  <DrawerForm
+    v-model="addEditUserVisible"
+    :title="form.id ? 'Edit user' : 'Add user'"
+    :loading="form.processing"
+    :errors="form.errors"
+    @submit="submit"
+  >
+    <div class="space-y-4 w-full">
+      <LabelField name="name" label="Name">
+        <InputText id="name" v-model="form.name" type="text" />
+      </LabelField>
+      <LabelField name="email" label="Email">
+        <InputText id="email" v-model="form.email" type="text" />
+      </LabelField>
+    </div>
+  </DrawerForm>
+
+  <DialogConfirmation
+    v-model="deleteUserVisible"
+    :message="`Are you sure you want to delete ${deleteUserData.value?.name || 'this user'}?`"
+    @confirm="confirmDelete"
+  />
+</template>

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -2,6 +2,7 @@
 import { useRoute } from 'vue-router';
 import LayoutApp from '@ui/components/App/Index.vue';
 import { Button, useModal } from '@atlas/ui';
+import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 
@@ -63,4 +64,5 @@ const route = useRoute();
             </div>
         </template>
     </LayoutApp>
+    <UserModals />
 </template>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue';
 import LayoutApp from '@ui/components/App/Index.vue';
 import { Table, ButtonMenu, TableActions, InputText, Button, Select, useModal } from '@atlas/ui';
+import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import LinkPaginator from '../components/LinkPaginator.vue';
 import { sideBarItems } from '../sideBarItems';
@@ -202,4 +203,5 @@ const userTotal = computed(() => users.value.total);
             [placeholder]
         </template>
     </LayoutApp>
+    <UserModals />
 </template>

--- a/ui/src/components/ButtonMenu.vue
+++ b/ui/src/components/ButtonMenu.vue
@@ -120,7 +120,7 @@ const onTriggerEnter = async () => {
 };
 
 const onTriggerLeave = (e: MouseEvent) => {
-    if (!props.onHover) return;
+    if (!isMenuOpen.value) return;
     const toEl = e.relatedTarget as Node | null;
     if (menu.value?.$el?.contains(toEl)) return;
     closeTimeout.value = setTimeout(() => {
@@ -130,14 +130,14 @@ const onTriggerLeave = (e: MouseEvent) => {
 
 const toggleMenu = () => {
     const el = getTriggerEl();
-    if (el) menu.value.toggle({ currentTarget: el });
+    if (el) setTimeout(() => menu.value.show({ currentTarget: el }), 0);
 };
 
 const onMenuShow = () => (isMenuOpen.value = true);
 const onMenuHide = () => (isMenuOpen.value = false);
 const onMenuEnter = () => clearTimeout(closeTimeout.value);
 const onMenuLeave = (e: MouseEvent) => {
-    if (!props.onHover) return;
+    if (!isMenuOpen.value) return;
     const toEl = e.relatedTarget as Node | null;
     const triggerEl = getTriggerEl();
     if (triggerEl?.contains(toEl)) return;


### PR DESCRIPTION
## Summary
- mock add/edit and delete user modals in playground using DrawerForm and DialogConfirmation
- include user modals on users table and user layout pages
- keep ButtonMenu open on repeated clicks and close when cursor leaves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aa1cb40c64832588508f18b9eef6fc