### PR TITLE
Standardize playground page layouts

### DIFF
--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -1,66 +1,26 @@
 <script setup>
-import { useRoute } from 'vue-router';
-import LayoutApp from '@ui/components/App/Index.vue';
-import { Button, useModal } from '@atlas/ui';
-import Link from '../components/RouterLink.vue';
+import { computed } from 'vue';
+import { useRoute, RouterView } from 'vue-router';
+import UiApp from '@ui/components/App/Index.vue';
+import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 
-const props = defineProps({
-    item: {
-        type: Object,
-        default: () => ({}),
-    },
-});
-
-const { open } = useModal();
 const route = useRoute();
+const pageTitle = computed(() => route.meta.title || '');
 </script>
 
 <template>
-    <LayoutApp
-        title="User"
-        :pageUrl="route.fullPath"
-        :pageTitle="'User'"
-        :sideBarItems="sideBarItems"
-        :linkComponent="Link"
-        :widthClass="'w-full'"
-        :isSideNav="true"
-    >
-        <template #navLogo>
-            <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
-        </template>
-        <template #headerTitle>
-            <div class="pr-2">
-                <Button
-                    as="a"
-                    text
-                    icon="pi pi-arrow-left"
-                    size="small"
-                    href="/users"
-                />
-            </div>
-            <div class="flex flex-col space-y-0 py-3">
-                <div class="text-md font-medium">{{ item.name }}</div>
-                <div class="text-sm text-slate-500">{{ item.email }}</div>
-            </div>
-        </template>
-        <template #headerAction>
-            <Button
-                size="small"
-                label="Edit"
-                @click="open('ADD_EDIT_USER', item)"
-            />
-        </template>
-        <template #pageSideContent>
-            <div class="h-[1000px] w-[350px] p-4">
-                <div>This is my side content</div>
-            </div>
-        </template>
-        <template #default>
-            <div class="h-[1000px]">
-                <div>This is my page content</div>
-                <div>{{ item }}</div>
-            </div>
-        </template>
-    </LayoutApp>
+  <UiApp
+    :pageUrl="route.fullPath"
+    :pageTitle="pageTitle"
+    :sideBarItems="sideBarItems"
+    :linkComponent="RouterLink"
+    :isSideNav="true"
+    :widthClass="'w-full'"
+  >
+    <template #navLogo>
+      <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
+    </template>
+    <RouterView />
+  </UiApp>
 </template>

--- a/playground/src/layouts/UsersLayout.vue
+++ b/playground/src/layouts/UsersLayout.vue
@@ -15,8 +15,10 @@ const pageTitle = computed(() => route.meta.title || '');
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
     :linkComponent="RouterLink"
-    :widthClass="'w-full'"
+    :containerClass="'p-0'"
+    :noScroll="true"
     :isSideNav="true"
+    :widthClass="'w-full'"
   >
     <template #navLogo>
       <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />

--- a/playground/src/pages/User.vue
+++ b/playground/src/pages/User.vue
@@ -1,0 +1,49 @@
+<script setup>
+import { Button, useModal } from '@atlas/ui';
+
+const props = defineProps({
+  item: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const { open } = useModal();
+</script>
+
+<template>
+  <template #headerTitle>
+    <div class="pr-2">
+      <Button
+        as="a"
+        text
+        icon="pi pi-arrow-left"
+        size="small"
+        href="/users"
+      />
+    </div>
+    <div class="flex flex-col space-y-0 py-3">
+      <div class="text-md font-medium">{{ item.name }}</div>
+      <div class="text-sm text-slate-500">{{ item.email }}</div>
+    </div>
+  </template>
+
+  <template #headerAction>
+    <Button
+      size="small"
+      label="Edit"
+      @click="open('ADD_EDIT_USER', item)"
+    />
+  </template>
+
+  <template #pageSideContent>
+    <div class="h-[1000px] w-[350px] p-4">
+      <div>This is my side content</div>
+    </div>
+  </template>
+
+  <div class="h-[1000px]">
+    <div>This is my page content</div>
+    <div>{{ item }}</div>
+  </div>
+</template>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -1,10 +1,7 @@
 <script setup>
 import { ref, computed } from 'vue';
-import LayoutApp from '@ui/components/App/Index.vue';
 import { Table, ButtonMenu, TableActions, InputText, Button, Select, useModal } from '@atlas/ui';
 import Link from '../components/RouterLink.vue';
-import LinkPaginator from '../components/LinkPaginator.vue';
-import { sideBarItems } from '../sideBarItems';
 
 const { open } = useModal();
 
@@ -115,91 +112,75 @@ const userTotal = computed(() => users.value.total);
 </script>
 
 <template>
-    <LayoutApp
-        title="Users"
-        :pageTitle="`Users (${userTotal})`"
-        containerClass="p-0"
-        :noScroll="true"
-        :sideBarItems="sideBarItems"
-        :linkComponent="Link"
-        :isSideNav="true"
-        :widthClass="'w-full'"
+  <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
+    <TableActions
+      :selectedCount="selectAll ? userTotal : selected?.length"
+      :menuItems="tableActionMenuItems"
+      @action="handleTableAction"
+    />
+  </template>
+  <template #headerAction>
+    <div class="flex items-center justify-between">
+      <div class="flex items-center space-x-2">
+        <InputText
+          v-model="search"
+          placeholder="Search user name or email"
+          class="w-[400px]"
+          size="small"
+          clearable
+        />
+        <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
+      </div>
+    </div>
+  </template>
+  <div class="bg-white dark:bg-surface-800">
+    <Table
+      :items="users.data"
+      :itemTotal="userTotal"
+      :columns="columns"
+      :sortField="sortField"
+      :sortOrder="sortOrder"
+      :selected="selected"
+      :selectAll="selectAll"
+      :defaultColumnList="defaultColumnList"
+      :activeColumnList="viewFields"
+      hasSelection
+      hasCustomizeColumns
+      :scrollOffset="53"
+      scrollable
+      @update:selected="selected = $event"
+      @update:selectAll="selectAll = $event"
+      @update:activeColumnList="viewFields = $event"
+      @sort="onSort"
     >
-        <template #navLogo>
-            <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
-        </template>
-        <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
-            <TableActions
-                :selectedCount="selectAll ? userTotal : selected?.length"
-                :menuItems="tableActionMenuItems"
-                @action="handleTableAction"
-            />
-        </template>
-        <template #headerAction>
-            <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-2">
-                    <InputText
-                        v-model="search"
-                        placeholder="Search user name or email"
-                        class="w-[400px]"
-                        size="small"
-                        clearable
-                    />
-                    <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
-                </div>
-            </div>
-        </template>
-        <template #default>
-            <div class="bg-white dark:bg-surface-800">
-                <Table
-                    :items="users.data"
-                    :itemTotal="userTotal"
-                    :columns="columns"
-                    :sortField="sortField"
-                    :sortOrder="sortOrder"
-                    :selected="selected"
-                    :selectAll="selectAll"
-                    :defaultColumnList="defaultColumnList"
-                    :activeColumnList="viewFields"
-                    hasSelection
-                    hasCustomizeColumns
-                    :scrollOffset="53"
-                    scrollable
-                    @update:selected="selected = $event"
-                    @update:selectAll="selectAll = $event"
-                    @update:activeColumnList="viewFields = $event"
-                    @sort="onSort"
-                >
-                    <template #edit="{ data }">
-                        <div class="w-full flex items-center justify-center">
-                            <ButtonMenu
-                                :items="[
-                                    { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
-                                    { separator: true },
-                                    { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
-                                ]"
-                            />
-                        </div>
-                    </template>
-                    <template #name="{ data }">
-                        <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
-                            {{ data.name }}
-                        </Link>
-                    </template>
-                </Table>
-            </div>
-        </template>
-        <template #footer>
-            <Select
-                v-model="perPage"
-                :options="perPageOptions"
-                size="small"
-                option-label="label"
-                option-value="value"
-            />
-        </template>
-        <template #footerAction>
-            [placeholder]
-        </template>
-    </LayoutApp>
+      <template #edit="{ data }">
+        <div class="w-full flex items-center justify-center">
+          <ButtonMenu
+            :items="[
+              { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
+              { separator: true },
+              { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
+            ]"
+          />
+        </div>
+      </template>
+      <template #name="{ data }">
+        <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
+          {{ data.name }}
+        </Link>
+      </template>
+    </Table>
+  </div>
+  <template #footer>
+    <Select
+      v-model="perPage"
+      :options="perPageOptions"
+      size="small"
+      option-label="label"
+      option-value="value"
+    />
+  </template>
+  <template #footerAction>
+    [placeholder]
+  </template>
 </template>

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from './pages/Home.vue';
 import Users from './pages/Users.vue';
+import User from './pages/User.vue';
 import Buttons from './pages/components/Buttons.vue';
 import Forms from './pages/components/forms/Index.vue';
 import FormsSizing from './pages/components/forms/Sizing.vue';
@@ -13,6 +14,7 @@ import EditorVariant from './pages/components/editor/Variant.vue';
 import EditorText from './pages/components/editor/Text.vue';
 import MainLayout from './layouts/MainLayout.vue';
 import UserLayout from './layouts/UserLayout.vue';
+import UsersLayout from './layouts/UsersLayout.vue';
 import ComponentsLayout from './layouts/ComponentsLayout.vue';
 
 const routes = [
@@ -25,20 +27,28 @@ const routes = [
   },
   {
     path: '/users',
-    component: Users,
-    meta: { title: 'Users table' },
+    component: UsersLayout,
+    children: [
+      { path: '', component: Users, meta: { title: 'Users table' } },
+    ],
   },
   {
     path: '/users/:id',
     component: UserLayout,
-    meta: { title: 'User details' },
-    props: route => ({
-      item: {
-        id: Number(route.params.id),
-        name: `User ${route.params.id}`,
-        email: `user${route.params.id}@example.com`,
+    children: [
+      {
+        path: '',
+        component: User,
+        meta: { title: 'User details' },
+        props: route => ({
+          item: {
+            id: Number(route.params.id),
+            name: `User ${route.params.id}`,
+            email: `user${route.params.id}@example.com`,
+          },
+        }),
       },
-    }),
+    ],
   },
   {
     path: '/components',


### PR DESCRIPTION
## Summary
- route Users through `UsersLayout` and move detail pages under `UserLayout`
- add dedicated `User` page and convert layout files to host child routes
- drop inline layout usage in `Users.vue` in favor of layout slots

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68aa1dc945d4832584d5fe6b61b61962