### PR TITLE
docs: add Vue component template snippet

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -3,6 +3,7 @@
 Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
 
 ## Table of Contents
+- [Component Guide](ui/component-guide.md)
 - [Application](#application)
 - [Override Themes with Passthrough](#override-themes-with-passthrough)
 - [Components](#components)

--- a/docs/ui/component-guide.md
+++ b/docs/ui/component-guide.md
@@ -1,0 +1,35 @@
+# Component Guide
+
+Use this template as a starting point for new Vue components. Blocks should appear in this order: template, script, then optional scoped styles.
+
+```vue
+<template>
+  <!-- Markup first, styled with Tailwind classes -->
+  <button
+    class="px-4 py-2 bg-primary-500 text-white rounded"
+    @click="emit('submit')"
+  >
+    {{ label }}
+  </button>
+</template>
+
+<script setup>
+// Props and emits defined with runtime options
+const props = defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['submit'])
+</script>
+
+<style scoped>
+/* Optional: add component-specific CSS overrides here */
+</style>
+```
+
+- The `<template>` block is optional for script-only components but belongs at the top when present.
+- Components are plain JavaScript by default; add `lang="ts"` to `<script setup>` only when TypeScript is required.
+- Tailwind CSS classes handle most styling; place any additional rules in a `<style scoped>` block at the end of the file.


### PR DESCRIPTION
## Summary
- add Vue component guide with `<script setup>`, `defineProps`, `defineEmits`, and Tailwind-first styling
- default component snippet to plain JavaScript; note `lang="ts"` is optional
- link component guide from UI docs

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa211041608325b2be498f4beb1c5e