### PR TITLE
Fix side nav activation for forms subpages in playground

### DIFF
--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -30,7 +30,7 @@ const pageNavItems = [
     label: 'Components',
     children: [
       { label: 'Buttons', href: '/components/buttons' },
-      { label: 'Forms', href: '/components/forms' },
+      { label: 'Forms', href: '/components/forms', parent: '/components/forms' },
       { label: 'Tables', href: '/components/tables' },
       { label: 'Tabs', href: '/components/tabs' },
       { label: 'Overlays', href: '/components/overlays' },


### PR DESCRIPTION
## Summary
- ensure Forms side nav item remains active on sizing and errors pages by checking parent path

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68ab1c597f10832582b183dcab5a6984