### PR TITLE
feat: add profile menu component

### DIFF
--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -7,6 +7,7 @@ Composes navigation, page chrome, and page content into a full application wrapp
 - App Navigation
   - [NavTopbar](application/nav-topbar.md)
   - [NavSidebar](application/nav-sidebar.md)
+  - [ProfileMenu](application/profile-menu.md)
 - App Layout
   - [App](#app)
   - [AppTopbar](application/app-topbar.md)

--- a/docs/ui/application/profile-menu.md
+++ b/docs/ui/application/profile-menu.md
@@ -1,0 +1,32 @@
+# ProfileMenu
+
+User avatar dropdown menu for account actions.
+
+## Example
+```ts
+import { ProfileMenu } from '@atlas/ui';
+```
+
+```vue
+<ProfileMenu
+  :user="user"
+  :items="profileMenuItems"
+  :avatar-only="true"
+  headerLink="/"
+  :linkComponent="RouterLink"
+/>
+```
+
+## Props
+- `avatarOnly: boolean` – render only the avatar as trigger. Default `false`.
+- `user: object` – user data containing `id`, `name`, and `email`.
+- `items: any[]` – menu item definitions.
+- `headerLink: string | null` – link for the header when `avatarOnly` is true. Default `null`.
+- `linkComponent: string | object` – component used for internal links. Default `'a'`.
+
+## Slots
+- `trigger` – custom trigger element. Slot props: `{ user, toggle }`.
+- `avatarMenuHeader` – content above menu items when `avatarOnly` is true.
+
+## Events
+- None

--- a/playground/src/layouts/MainLayout.vue
+++ b/playground/src/layouts/MainLayout.vue
@@ -10,17 +10,46 @@
     <template #navLogo>
       <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
     </template>
+    <template #navActions>
+      <ProfileMenu
+        :user="user"
+        :items="profileMenuItems"
+        :avatar-only="true"
+        headerLink="/"
+        :linkComponent="RouterLink"
+      />
+    </template>
     <RouterView />
   </UiApp>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
+import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 
 const route = useRoute();
 const pageTitle = computed(() => route.meta.title || '');
+
+const user = ref({
+  id: 1,
+  name: 'Jane Doe',
+  email: 'jane@example.com'
+});
+
+const profileMenuItems = computed(() => [
+  { separator: true },
+  { label: 'Company Name', icon: 'pi pi-building-columns', href: '/' },
+  { separator: true },
+  { label: 'Billing & Plan', icon: 'pi pi-credit-card', href: '/' },
+  { label: 'Manage Access', icon: 'pi pi-users', href: '/' },
+  { label: 'Integrations', icon: 'pi pi-objects-column', href: '/' },
+  { label: 'Settings', icon: 'pi pi-cog', href: '/' },
+  { label: 'Status page', icon: 'pi pi-cog', href: 'https://google.com', external: true },
+  { separator: true },
+  { label: 'Logout', icon: 'pi pi-sign-out', href: '/logout' }
+]);
 </script>

--- a/ui/src/components/App/Nav/ProfileMenu.vue
+++ b/ui/src/components/App/Nav/ProfileMenu.vue
@@ -1,0 +1,113 @@
+<template>
+    <div class="relative">
+        <div v-if="user?.id" class="flex justify-center items-center">
+            <slot name="trigger" :user="user" :toggle="toggle">
+                <button
+                    class="relative overflow-hidden w-full mr-2 p-link flex items-center p-2 px-3 rounded-md text-surface-800 dark:text-white hover:bg-surface-200 dark:hover:bg-surface-600 border-noround cursor-pointer"
+                    :class="{ '!p-1 !py-2 !mr-0': avatarOnly }"
+                    @click="toggle"
+                >
+                    <Avatar
+                        :label="user.name?.charAt(0).toUpperCase()"
+                        class="m-auto border border-surface-200 dark:border-surface-400 bg-surface-100 text-surface-800 dark:bg-surface-700 dark:text-white"
+                        shape="circle"
+                    />
+                    <div v-if="!avatarOnly" class="ml-2 flex flex-col text-left flex-1 min-w-0">
+                        <span class="font-bold truncate">{{ user.name }}</span>
+                        <span class="text-sm truncate">{{ user.email }}</span>
+                    </div>
+                </button>
+            </slot>
+            <Menu ref="menu" :model="menuItems" class="w-[245px] !z-[99999]" popup>
+                <template v-if="avatarOnly" #start>
+                    <slot name="avatarMenuHeader">
+                        <div class="p-1 pb-0">
+                            <component
+                                :is="headerLink ? linkComponent : 'div'"
+                                :href="headerLink"
+                                class="relative overflow-hidden w-full p-link flex items-center p-2 rounded"
+                                :class="headerLink
+                                    ? 'text-surface-800 dark:text-white hover:bg-surface-100 dark:hover:bg-surface-600 cursor-pointer'
+                                    : 'text-surface-800 dark:text-white cursor-default'"
+                            >
+                                <Avatar
+                                    :label="user?.name?.charAt(0).toUpperCase()"
+                                    class="mr-2 border border-surface-200 dark:border-surface-400"
+                                    shape="circle"
+                                />
+                                <div class="flex flex-col text-left flex-1 min-w-0">
+                                    <span class="font-bold truncate">{{ user?.name }}</span>
+                                    <span class="text-sm truncate">{{ user?.email }}</span>
+                                </div>
+                            </component>
+                        </div>
+                    </slot>
+                </template>
+                <template #item="{ item, props }">
+                    <component
+                        :is="item.external ? 'a' : linkComponent"
+                        :href="item.href"
+                        v-bind="props.action"
+                        class="flex items-center justify-between text-surface-800 dark:text-white hover:bg-surface-100 dark:hover:bg-surface-700 p-2 px-3 w-full rounded"
+                    >
+                        <div class="flex align-items-center items-center">
+                            <span :class="item.icon" />
+                            <span class="ml-2 text-sm">{{ item.label }}</span>
+                            <Badge
+                                v-if="item.badge"
+                                class="ml-auto"
+                                :value="item.badge"
+                            />
+                            <span v-if="item.shortcut" class="ml-auto border border-surface-300 rounded bg-surface-100 text-xs p-1">
+                                {{ item.shortcut }}
+                            </span>
+                        </div>
+                        <IconArrowUpRight
+                            v-if="item.external"
+                            class="ml-2 w-4 h-4 opacity-50"
+                        />
+                    </component>
+                </template>
+            </Menu>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { IconArrowUpRight } from '@tabler/icons-vue';
+import Avatar from '../../Avatar.vue';
+import Badge from '../../Badge.vue';
+import Menu from '../../Menu.vue';
+
+const props = defineProps({
+    avatarOnly: {
+        type: Boolean,
+        default: false
+    },
+    user: {
+        type: Object,
+        default: () => ({})
+    },
+    items: {
+        type: Array,
+        default: () => ([])
+    },
+    headerLink: {
+        type: String,
+        default: null
+    },
+    linkComponent: {
+        type: [String, Object],
+        default: 'a'
+    }
+});
+
+const menu = ref();
+const menuItems = computed(() => props.items);
+
+const toggle = (event) => {
+    menu.value.toggle(event);
+};
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -60,6 +60,7 @@ export { default as PageSideContent } from './App/Page/SideContent.vue';
 export { default as PageSideNav } from './App/Page/SideNav.vue';
 export { default as NavSidebar } from './App/Nav/Sidebar.vue';
 export { default as NavTopbar } from './App/Nav/Topbar.vue';
+export { default as ProfileMenu } from './App/Nav/ProfileMenu.vue';
 export { default as Table } from './App/Table/Table.vue';
 export { default as TableActions } from './App/Table/Actions.vue';
 export { default as TableCustomizeColumns } from './App/Table/CustomizeColumns.vue';


### PR DESCRIPTION
## Summary
- add ProfileMenu component for avatar-driven navigation
- document ProfileMenu and link from application docs
- demo ProfileMenu in playground navigation

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab5217df608325b38f2b281cd1fced