### PR TITLE
feat: add custom file upload component

### DIFF
--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -53,6 +53,11 @@
                 <Textarea id="description_invalid" v-model="form.description" fluid autoResize :invalid="true" />
               </LabelField>
             </div>
+            <div class="w-full">
+              <LabelField name="file" label="File" :error="errors.file">
+                <FileUpload v-model="form.file" clearable invalid />
+              </LabelField>
+            </div>
           </div>
         </template>
         <template #footer>
@@ -82,6 +87,7 @@ import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import Textarea from '@atlas/ui/components/Textarea.vue';
 import { useModal } from '@atlas/ui/composables';
 import Errors from '@atlas/ui/components/Errors.vue';
+import FileUpload from '@atlas/ui/components/FileUpload.vue';
 
 const { open } = useModal();
 
@@ -95,6 +101,7 @@ const form = reactive({
   month: null,
   time: null,
   description: null,
+  file: null,
 });
 
 const errors = reactive({
@@ -107,6 +114,7 @@ const errors = reactive({
   month: 'Month is required',
   time: 'Time is required',
   description: 'Description is required',
+  file: 'File is required',
 });
 
 const roles = ref([

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -132,6 +132,11 @@
                   <Textarea id="description_disabled" v-model="form.description" fluid :disabled="true" autoResize />
                 </LabelField>
               </div>
+              <div class="w-full">
+                <LabelField name="file" label="File">
+                  <FileUpload v-model="form.file" clearable :disabled="true" />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -66,6 +66,11 @@
                   <Textarea id="description" v-model="form.description" fluid autoResize />
                 </LabelField>
               </div>
+              <div class="w-full">
+                <LabelField name="file" label="File">
+                  <FileUpload v-model="form.file" clearable />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>
@@ -241,6 +246,7 @@ import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
 import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import Textarea from '@atlas/ui/components/Textarea.vue';
+import FileUpload from '@atlas/ui/components/FileUpload.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Alert from '@atlas/ui/components/Alert.vue';
 import LabelCheckbox from '@atlas/ui/components/LabelCheckbox.vue';
@@ -266,6 +272,7 @@ const form = reactive({
     month: new Date('2024-02-01'),
     time: new Date('2024-01-01T12:00:00'),
     description: 'Example description',
+    file: null,
 });
 
 const roles = ref([

--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -69,6 +69,11 @@
               <DatePicker v-model="form.time" timeOnly fluid :size="item.size" />
             </LabelField>
           </div>
+          <div class="w-full">
+            <LabelField name="file" label="File">
+              <FileUpload v-model="form.file" clearable :size="item.size" />
+            </LabelField>
+          </div>
         </div>
       </template>
       <template #footer>
@@ -92,6 +97,7 @@ import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
 import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Button from '@atlas/ui/components/Button.vue';
+import FileUpload from '@atlas/ui/components/FileUpload.vue';
 
 const form = reactive({
   first_name: 'John',
@@ -108,6 +114,7 @@ const form = reactive({
   date: null,
   month: null,
   time: null,
+  file: null,
   query: null,
 });
 

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -1,7 +1,14 @@
 <template>
     <div class="relative">
-        <InputGroup :class="rootClass" :style="rootStyle">
-            <Button type="button" label="Choose" @click="choose" :disabled="isDisabled" />
+        <InputGroup :class="['p-1', sizeClass, invalidClass, rootClass]" :style="rootStyle">
+            <Button
+                type="button"
+                :label="chooseLabel"
+                @click="choose"
+                :disabled="isDisabled"
+                :size="props.size"
+                class="mr-2"
+            />
             <div class="relative flex-1">
                 <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
                     <span class="truncate">{{ fileNames || 'No file selected' }}</span>
@@ -38,14 +45,24 @@ interface Props {
     modelValue?: File | File[] | null;
     multiple?: boolean;
     clearable?: boolean;
+    chooseLabel?: string;
+    size?: 'small' | 'large';
+    invalid?: boolean;
 }
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    chooseLabel: 'Choose',
+    size: undefined,
+    invalid: false,
+});
 const emit = defineEmits(['update:modelValue']);
 
 const attrs = useAttrs();
 
 const rootClass = computed(() => (attrs as any).class);
 const rootStyle = computed(() => (attrs as any).style);
+
+const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
+const invalidClass = computed(() => (props.invalid ? 'p-invalid' : ''));
 const inputAttrs = computed(() => {
     const { class: _c, style: _s, ...rest } = attrs as any;
     return rest;

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -21,6 +21,7 @@
                 :disabled="isDisabled"
                 :size="props.size"
                 class="mr-2"
+                :class="buttonPaddingClass"
             />
             <div class="relative flex-1">
                 <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
@@ -79,7 +80,17 @@ const paddingClass = computed(() =>
     props.size === 'small' ? 'px-px py-0' : 'px-1 py-0'
 );
 const baseClass =
-    'flex items-stretch rounded-md border border-surface-300 dark:border-surface-700 focus-within:border-primary p-invalid:border-red-500 dark:p-invalid:border-red-500 transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
+    'flex items-center rounded-md border border-surface-300 dark:border-surface-700 focus-within:border-primary p-invalid:border-red-400 dark:p-invalid:border-red-500 transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
+const buttonPaddingClass = computed(() => {
+    switch (props.size) {
+        case 'small':
+            return '!py-1';
+        case 'large':
+            return '!py-2';
+        default:
+            return '!py-1.5';
+    }
+});
 const inputAttrs = computed(() => {
     const { class: _c, style: _s, ...rest } = attrs as any;
     return rest;
@@ -114,9 +125,9 @@ const hasFile = computed(() => !!fileNames.value);
 
 const textBase = `flex items-center w-full
     bg-surface-0 dark:bg-surface-950
-    px-3 py-[9px] leading-[1.25rem] text-base
-    p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
-    p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+    px-3 py-[9px] leading-[1.25rem] text-sm
+    p-small:text-xs p-small:px-[0.625rem] p-small:py-[0.375rem]
+    p-large:text-base p-large:px-[0.875rem] p-large:py-[0.625rem]
     transition-colors duration-200`;
 </script>
 

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -1,10 +1,23 @@
 <template>
     <div class="relative">
-        <InputGroup :class="['p-1', sizeClass, invalidClass, rootClass]" :style="rootStyle">
+        <div
+            :class="[
+                baseClass,
+                paddingClass,
+                sizeClass,
+                invalidClass,
+                isDisabled
+                    ? 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-400 opacity-70 shadow-none cursor-not-allowed'
+                    : 'bg-surface-0 dark:bg-surface-950 text-surface-900 dark:text-surface-0 hover:border-surface-400 dark:hover:border-surface-600 cursor-pointer',
+                rootClass,
+            ]"
+            :style="rootStyle"
+            @click="onContainerClick"
+        >
             <Button
                 type="button"
                 :label="chooseLabel"
-                @click="choose"
+                @click.stop="choose"
                 :disabled="isDisabled"
                 :size="props.size"
                 class="mr-2"
@@ -16,14 +29,14 @@
                 <button
                     v-if="clearable && hasFile"
                     type="button"
-                    @click="clear"
+                    @click.stop="clear"
                     :disabled="isDisabled"
                     class="absolute top-1/2 -translate-y-1/2 right-3 text-surface-400 hover:text-surface-600 dark:text-surface-300 dark:hover:text-white cursor-pointer disabled:hidden disabled:pointer-events-none"
                 >
                     <TimesIcon class="w-4 h-4" />
                 </button>
             </div>
-        </InputGroup>
+        </div>
         <input
             ref="input"
             type="file"
@@ -38,7 +51,6 @@
 <script setup lang="ts">
 import { ref, computed, useAttrs } from 'vue';
 import Button from './Button.vue';
-import InputGroup from './InputGroup.vue';
 import TimesIcon from '@primevue/icons/times';
 
 interface Props {
@@ -63,6 +75,11 @@ const rootStyle = computed(() => (attrs as any).style);
 
 const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
 const invalidClass = computed(() => (props.invalid ? 'p-invalid' : ''));
+const paddingClass = computed(() =>
+    props.size === 'small' ? 'px-px py-0' : 'px-1 py-0'
+);
+const baseClass =
+    'flex items-stretch rounded-md border border-surface-300 dark:border-surface-700 focus-within:border-primary p-invalid:border-red-500 dark:p-invalid:border-red-500 transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
 const inputAttrs = computed(() => {
     const { class: _c, style: _s, ...rest } = attrs as any;
     return rest;
@@ -72,6 +89,9 @@ const isDisabled = computed(() => !!inputAttrs.value.disabled);
 
 const input = ref<HTMLInputElement>();
 const choose = () => input.value?.click();
+const onContainerClick = () => {
+    if (!isDisabled.value) choose();
+};
 
 const onChange = (e: Event) => {
     const files = (e.target as HTMLInputElement).files;
@@ -94,7 +114,7 @@ const hasFile = computed(() => !!fileNames.value);
 
 const textBase = `flex items-center w-full
     bg-surface-0 dark:bg-surface-950
-    px-3 py-[9px] leading-[1.25rem]
+    px-3 py-[9px] leading-[1.25rem] text-base
     p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
     p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
     transition-colors duration-200`;

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -1,0 +1,85 @@
+<template>
+    <div class="relative">
+        <InputGroup :class="rootClass" :style="rootStyle">
+            <Button type="button" label="Choose" @click="choose" :disabled="isDisabled" />
+            <div class="relative flex-1">
+                <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
+                    <span class="truncate">{{ fileNames || 'No file selected' }}</span>
+                </div>
+                <button
+                    v-if="clearable && hasFile"
+                    type="button"
+                    @click="clear"
+                    :disabled="isDisabled"
+                    class="absolute top-1/2 -translate-y-1/2 right-3 text-surface-400 hover:text-surface-600 dark:text-surface-300 dark:hover:text-white cursor-pointer disabled:hidden disabled:pointer-events-none"
+                >
+                    <TimesIcon class="w-4 h-4" />
+                </button>
+            </div>
+        </InputGroup>
+        <input
+            ref="input"
+            type="file"
+            class="hidden"
+            :multiple="multiple"
+            @change="onChange"
+            v-bind="inputAttrs"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, useAttrs } from 'vue';
+import Button from './Button.vue';
+import InputGroup from './InputGroup.vue';
+import TimesIcon from '@primevue/icons/times';
+
+interface Props {
+    modelValue?: File | File[] | null;
+    multiple?: boolean;
+    clearable?: boolean;
+}
+const props = defineProps<Props>();
+const emit = defineEmits(['update:modelValue']);
+
+const attrs = useAttrs();
+
+const rootClass = computed(() => (attrs as any).class);
+const rootStyle = computed(() => (attrs as any).style);
+const inputAttrs = computed(() => {
+    const { class: _c, style: _s, ...rest } = attrs as any;
+    return rest;
+});
+
+const isDisabled = computed(() => !!inputAttrs.value.disabled);
+
+const input = ref<HTMLInputElement>();
+const choose = () => input.value?.click();
+
+const onChange = (e: Event) => {
+    const files = (e.target as HTMLInputElement).files;
+    if (!files) return;
+    emit('update:modelValue', props.multiple ? Array.from(files) : files[0] ?? null);
+};
+
+const clear = () => {
+    emit('update:modelValue', props.multiple ? [] : null);
+    if (input.value) input.value.value = '';
+};
+
+const model = computed(() => props.modelValue);
+const fileNames = computed(() => {
+    const value = model.value;
+    if (!value || (Array.isArray(value) && value.length === 0)) return '';
+    return Array.isArray(value) ? value.map((f) => f.name).join(', ') : value.name;
+});
+const hasFile = computed(() => !!fileNames.value);
+
+const textBase = `flex items-center w-full
+    bg-surface-0 dark:bg-surface-950
+    px-3 py-[9px] leading-[1.25rem]
+    p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+    p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+    transition-colors duration-200`;
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -7,6 +7,7 @@ export { default as InputMask } from './InputMask.vue';
 export { default as InputNumber } from './InputNumber.vue';
 export { default as InputOtp } from './InputOtp.vue';
 export { default as InputText } from './InputText.vue';
+export { default as FileUpload } from './FileUpload.vue';
 export { default as Alert } from './Alert.vue';
 export { default as Errors } from './Errors.vue';
 export { default as Select } from './Select.vue';

--- a/ui/tests/components/FileUpload.test.ts
+++ b/ui/tests/components/FileUpload.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import FileUpload from '../../src/components/FileUpload.vue';
+
+describe('FileUpload', () => {
+    it('emits selected file and clears', async () => {
+        const wrapper = mount(FileUpload, {
+            props: { clearable: true },
+            global: { plugins: [PrimeVue] },
+        });
+        const input = wrapper.find('input[type="file"]');
+        const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+        Object.defineProperty(input.element, 'files', {
+            value: [file],
+        });
+        await input.trigger('change');
+        expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toBe(file);
+        await wrapper.setProps({ modelValue: file });
+        const buttons = wrapper.findAll('button');
+        await buttons[1].trigger('click');
+        expect(wrapper.emitted('update:modelValue')?.[1]?.[0]).toBeNull();
+    });
+});

--- a/ui/tests/components/FileUpload.test.ts
+++ b/ui/tests/components/FileUpload.test.ts
@@ -21,4 +21,13 @@ describe('FileUpload', () => {
         await buttons[1].trigger('click');
         expect(wrapper.emitted('update:modelValue')?.[1]?.[0]).toBeNull();
     });
+
+    it('renders custom choose label', () => {
+        const wrapper = mount(FileUpload, {
+            props: { chooseLabel: 'Select' },
+            global: { plugins: [PrimeVue] },
+        });
+        const button = wrapper.find('button');
+        expect(button.text()).toBe('Select');
+    });
 });


### PR DESCRIPTION
## Summary
- add standalone `FileUpload` component with choose button, file list display, and clearable option
- showcase FileUpload in playground form demo
- export FileUpload and include unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab5ab65d3c83258f6540e8c2f5fc6d