### PR TITLE
Add quick drop transition for tooltips

### DIFF
--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -35,7 +35,7 @@
                                 v-tooltip.right="{
                                     value: child.label,
                                         pt: {
-                                            root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px] ml-3',
+                                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] ml-3',
                                             text: autoDark
                                                 ? 'text-sm p-2 border border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white rounded whitespace-pre-line'
                                                 : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -93,7 +93,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { items, linkComponent } = props;
 
 const tooltipPt = {
-    root: 'absolute ml-2 shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    root: 'absolute ml-2 shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 };
 

--- a/ui/src/components/App/Table/Actions.vue
+++ b/ui/src/components/App/Table/Actions.vue
@@ -11,7 +11,7 @@
                 v-tooltip.bottom="{
                     value: menuItem?.tooltip ?? null,
                     pt: {
-                        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px] mt-1',
+                        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
                         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
                     }
                 }"
@@ -73,7 +73,7 @@
                     v-tooltip.bottom="{
                         value: 'Clear selection',
                         pt: {
-                            root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px] mt-1',
+                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
                             text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
                         }
                     }"

--- a/ui/src/components/App/Table/Table.vue
+++ b/ui/src/components/App/Table/Table.vue
@@ -12,7 +12,7 @@
                         v-tooltip.left="{
                             value: 'Customize columns',
                             pt: {
-                                root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+                                root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
                                 text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
                             }
                         }"

--- a/ui/src/components/Editor/Tools/BoldTool.vue
+++ b/ui/src/components/Editor/Tools/BoldTool.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 const tooltip = {
     value: 'Bold',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/BulletListTool.vue
+++ b/ui/src/components/Editor/Tools/BulletListTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Bullet list',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/ClearFormattingTool.vue
+++ b/ui/src/components/Editor/Tools/ClearFormattingTool.vue
@@ -22,7 +22,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Clear formatting',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/ItalicTool.vue
+++ b/ui/src/components/Editor/Tools/ItalicTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Italic',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/LinkTool.vue
+++ b/ui/src/components/Editor/Tools/LinkTool.vue
@@ -78,7 +78,7 @@ const toggleLinkPopover = (event) => {
 const tooltip = {
     value: 'Add link',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/OrderedListTool.vue
+++ b/ui/src/components/Editor/Tools/OrderedListTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Numbered list',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/StrikeTool.vue
+++ b/ui/src/components/Editor/Tools/StrikeTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Strikethrough',
     pt: {
-        root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
     }
 };

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -39,7 +39,7 @@ const theme = computed<TooltipIconPassThroughOptions>(() => ({
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
-    root: 'absolute shadow-md p-fadein py-0 px-0 max-w-[260px]',
+    root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
 });
 

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,3 +1,5 @@
+import './style.css';
+
 export * from './components';
 export * from './composables';
 export * from './utils';

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,0 +1,14 @@
+.atlas-tooltip {
+  animation: atlas-tooltip-drop 75ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes atlas-tooltip-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,11 +1,11 @@
 .atlas-tooltip {
-  animation: atlas-tooltip-drop 75ms cubic-bezier(0.4, 0, 0.2, 1);
+  animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @keyframes atlas-tooltip-drop {
   from {
     opacity: 0;
-    transform: translateY(-2px);
+    transform: translateY(-8px);
   }
   to {
     opacity: 1;


### PR DESCRIPTION
## Summary
- add atlas-tooltip animation and global style import
- update tooltip pass-through options across components to use quick drop effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab6a022b2c83258f93838a82d1eb5d