### PR TITLE
Use theme radius for nav and dialog

### DIFF
--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -41,7 +41,7 @@
                                                 : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                                         }
                                 }"
-                                class="relative flex items-center justify-center w-full h-12 mt-2 rounded"
+                                class="relative flex items-center justify-center w-full h-12 mt-2 rounded-[var(--p-content-border-radius)]"
                                 :href="child.href"
                                 :class="linkClass(child)"
                             >

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -30,14 +30,14 @@
                                 v-if="!item.children"
                                 :is="linkComponent"
                                 :href="item.href"
-                                class="rounded-md px-3 py-2 text-sm font-medium"
+                                class="rounded-[var(--p-content-border-radius)] px-3 py-2 text-sm font-medium"
                                 :class="linkClass(item)"
                             >
                                 {{ item.label }}
                             </component>
                             <div
                                 v-else
-                                class="rounded-md px-3 py-2 text-sm font-medium cursor-pointer"
+                                class="rounded-[var(--p-content-border-radius)] px-3 py-2 text-sm font-medium cursor-pointer"
                                 :class="linkClass(item)"
                                 @click="toggleMenu(item.href, $event)"
                             >
@@ -53,7 +53,7 @@
                                             :is="linkComponent"
                                             v-bind="props.action"
                                             :href="item.href"
-                                            class="flex items-center w-full px-2 py-1 text-sm rounded"
+                                            class="flex items-center w-full px-2 py-1 text-sm rounded-[var(--p-content-border-radius)]"
                                             :class="{
                                                 'bg-surface-200 dark:bg-surface-800 dark:text-white': isActive(item)
                                             }"

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -15,7 +15,7 @@
                                 <component
                                     :is="linkComponent"
                                     :href="child.href"
-                                    class="block rounded px-4 py-2 text-sm font-medium"
+                                    class="block rounded-[var(--p-content-border-radius)] px-4 py-2 text-sm font-medium"
                                     :class="[
                                         isActive(child)
                                             ? 'bg-surface-100 dark:bg-surface-700 text-primary-800 dark:text-white font-semibold'
@@ -41,7 +41,7 @@
                         v-else
                         :is="linkComponent"
                         :href="item.href"
-                        class="block rounded px-4 py-2 text-sm font-medium"
+                        class="block rounded-[var(--p-content-border-radius)] px-4 py-2 text-sm font-medium"
                         :class="[
                             isActive(item)
                                 ? 'bg-surface-100 dark:bg-surface-700 text-primary-800 dark:text-white font-semibold'

--- a/ui/src/components/Dialog.vue
+++ b/ui/src/components/Dialog.vue
@@ -40,7 +40,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<DialogPassThroughOptions>({
-    root: `max-h-[90%] max-w-screen rounded-md
+    root: `max-h-[90%] max-w-screen rounded-[var(--p-content-border-radius)]
         border border-surface-200 dark:border-surface-700
         bg-surface-0 dark:bg-surface-900
         text-surface-700 dark:text-surface-0 shadow-lg


### PR DESCRIPTION
## Summary
- use theme border radius for side nav links
- apply theme radius to topbar navigation
- update dialog modal to use theme border radius

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab7e86447c83258c057fda73bb7fcf