### PR TITLE
Guard isPageActive for SSR safety

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -352,7 +352,7 @@ roundTo(123.456, 1); // 123.5
 
 ### isPageActive
 
-Determines whether the current Inertia page URL matches a given path.
+Determines whether the current Inertia page URL matches a given path. This utility returns `false` during server-side rendering to avoid accessing browser-only globals.
 
 **Parameters:**
 - `itemPath` (string): The path to compare against the current page URL.

--- a/src/utils/vue/index.ts
+++ b/src/utils/vue/index.ts
@@ -1,3 +1,4 @@
 export * from './ptViewMerge';
 export * from './hasSlotContent';
 export * from './ptMerge';
+export * from './inertia';

--- a/src/utils/vue/inertia/isPageActive.ts
+++ b/src/utils/vue/inertia/isPageActive.ts
@@ -1,4 +1,5 @@
 import { usePage } from '@inertiajs/vue3';
+import { isClient } from '../../browser';
 
 /**
  * Determine whether the current Inertia page is active.
@@ -13,6 +14,8 @@ export const isPageActive = (
     itemParent?: string,
     eq = false
 ): boolean => {
+    if (!isClient) return false;
+
     const page = usePage();
     const path = itemParent ?? itemPath;
     const currentPath = new URL(page.url, document.baseURI).pathname;

--- a/tests/utils/vue/isPageActive.ssr.test.ts
+++ b/tests/utils/vue/isPageActive.ssr.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ url: '/users' }),
+}));
+
+vi.mock('../../../src/utils/browser', () => ({ isClient: false }));
+
+import { isPageActive } from '../../../src/utils';
+
+describe('isPageActive - SSR', () => {
+    it('returns false when not running on the client', () => {
+        expect(isPageActive('/users')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- guard `isPageActive` with `isClient` to avoid document access during SSR
- re-export inertia utilities and document SSR behaviour
- add SSR test for `isPageActive`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af21ea344c8325a872389cb2be93b5